### PR TITLE
fix(gateway): update client metadata patch offsets

### DIFF
--- a/MemoryDumper/MemoryDumper.csproj
+++ b/MemoryDumper/MemoryDumper.csproj
@@ -9,4 +9,8 @@
     <PlatformTarget>x64</PlatformTarget>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
 </Project>

--- a/Schale/Schale.csproj
+++ b/Schale/Schale.csproj
@@ -8,6 +8,10 @@
 	  <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
   <ItemGroup>
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="Google.FlatBuffers" Version="25.2.10" />

--- a/Shittim-Server.sln
+++ b/Shittim-Server.sln
@@ -1,0 +1,81 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "MemoryDumper", "MemoryDumper\MemoryDumper.csproj", "{80845D56-1A88-4F35-82C0-13D60FB9906E}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Schale", "Schale\Schale.csproj", "{A013173F-4367-418C-802F-2E6335452D7F}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Shittim-Server", "Shittim-Server\Shittim-Server.csproj", "{036E6E1C-D40D-468A-985E-24CA96646316}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Tools", "Tools", "{07C2787E-EAC7-C090-1BA3-A61EC2A24D84}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ExcelDbKeyTool", "Tools\ExcelDbKeyTool\ExcelDbKeyTool.csproj", "{148F5A79-6B1D-40C1-A5BC-18999019FF18}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Debug|x64.Build.0 = Debug|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Debug|x86.Build.0 = Debug|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Release|Any CPU.Build.0 = Release|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Release|x64.ActiveCfg = Release|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Release|x64.Build.0 = Release|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Release|x86.ActiveCfg = Release|Any CPU
+		{80845D56-1A88-4F35-82C0-13D60FB9906E}.Release|x86.Build.0 = Release|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Debug|x64.Build.0 = Debug|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Debug|x86.Build.0 = Debug|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Release|Any CPU.Build.0 = Release|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Release|x64.ActiveCfg = Release|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Release|x64.Build.0 = Release|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Release|x86.ActiveCfg = Release|Any CPU
+		{A013173F-4367-418C-802F-2E6335452D7F}.Release|x86.Build.0 = Release|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Debug|x64.Build.0 = Debug|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Debug|x86.Build.0 = Debug|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Release|Any CPU.Build.0 = Release|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Release|x64.ActiveCfg = Release|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Release|x64.Build.0 = Release|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Release|x86.ActiveCfg = Release|Any CPU
+		{036E6E1C-D40D-468A-985E-24CA96646316}.Release|x86.Build.0 = Release|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Debug|x64.Build.0 = Debug|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Debug|x86.Build.0 = Debug|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Release|Any CPU.Build.0 = Release|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Release|x64.ActiveCfg = Release|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Release|x64.Build.0 = Release|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Release|x86.ActiveCfg = Release|Any CPU
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{148F5A79-6B1D-40C1-A5BC-18999019FF18} = {07C2787E-EAC7-C090-1BA3-A61EC2A24D84}
+	EndGlobalSection
+EndGlobal

--- a/Shittim-Server/CLI/GameServer.cs
+++ b/Shittim-Server/CLI/GameServer.cs
@@ -211,15 +211,17 @@ namespace Shittim.CLI
                     var handlerManager = scope.ServiceProvider.GetRequiredService<HandlerManager>();
                     handlerManager.Initialize();
 
-                    if (console)
+                    var shouldStartConsoleCommands = console || (Environment.UserInteractive && !Console.IsInputRedirected);
+                    if (shouldStartConsoleCommands)
                     {
                         var consoleConnection = new ConsoleClientConnection(
                             contextFactory,
                             mapper,
                             excelService,
                             new StreamWriter(Console.OpenStandardOutput()),
-                            id ?? 2
+                            id ?? 0
                         );
+                        Console.WriteLine("Console GM command listener enabled");
                         _ = Task.Run(() => ConsoleCommand.ConsoleCommandListener(consoleConnection));
                     }
                 }

--- a/Shittim-Server/Services/Client/ConsoleCommand.cs
+++ b/Shittim-Server/Services/Client/ConsoleCommand.cs
@@ -1,3 +1,5 @@
+using Microsoft.EntityFrameworkCore;
+using Schale.Data.GameModel;
 using Shittim.Commands;
 using Serilog;
 
@@ -8,28 +10,170 @@ namespace Shittim.Services.Client
         public static async Task ConsoleCommandListener(ConsoleClientConnection connection)
         {
             Log.Information("Starting console command with UID: {uid}", connection.AccountServerId);
+            await InitializeTargetAccount(connection);
+            await connection.SendChatMessage("Console GM ready. Use `uid <accountId>` to switch account, `accounts` to list accounts, `whoami` to show current account.");
+
             while (true)
             {
                 var input = Console.ReadLine();
+                if (input == null)
+                {
+                    await Task.Delay(100);
+                    continue;
+                }
+
+                input = input.Trim();
                 if (string.IsNullOrEmpty(input) || connection == null)
                     continue;
 
-                if (input.StartsWith('/'))
+                if (await TryHandleLocalCommand(connection, input))
+                    continue;
+
+                var normalizedInput = input.StartsWith('/') ? input : "/" + input;
+                if (normalizedInput.StartsWith('/'))
                 {
                     try
                     {
-                        var args = input.Split(' ');
+                        var args = normalizedInput.Split(' ', StringSplitOptions.RemoveEmptyEntries);
                         var commandName = args[0].TrimStart('/').ToLower();
                         var commandArgs = args.Skip(1).ToArray();
 
+                        if (!CommandFactory.commands.ContainsKey(commandName))
+                        {
+                            await connection.SendChatMessage($"Unknown command: {commandName}");
+                            continue;
+                        }
+
+                        if (!await EnsureTargetAccountSelected(connection))
+                            continue;
+
                         var command = CommandFactory.CreateCommand(commandName, connection, commandArgs);
-                        command?.Execute();
+                        if (command == null)
+                        {
+                            await connection.SendChatMessage($"Unknown command: {commandName}");
+                            continue;
+                        }
+
+                        await command.Execute();
                     }
                     catch (Exception ex)
                     {
                         Console.WriteLine($"Error executing command: {ex.Message}");
                     }
                 }
+            }
+        }
+
+        private static async Task<bool> TryHandleLocalCommand(ConsoleClientConnection connection, string input)
+        {
+            var parts = input.Split(' ', StringSplitOptions.RemoveEmptyEntries);
+            if (parts.Length == 0)
+                return true;
+
+            var localCommand = parts[0].TrimStart('/').ToLowerInvariant();
+            switch (localCommand)
+            {
+                case "uid":
+                case "use":
+                    if (parts.Length < 2 || !long.TryParse(parts[1], out var accountId))
+                    {
+                        await connection.SendChatMessage("Usage: uid <accountId>");
+                        return true;
+                    }
+
+                    await SelectTargetAccount(connection, accountId);
+                    return true;
+
+                case "whoami":
+                    if (await TryGetCurrentAccount(connection) is AccountDBServer account)
+                        await connection.SendChatMessage($"Current account: UID {account.ServerId}, Nickname: {account.Nickname}, Level: {account.Level}");
+                    else
+                        await connection.SendChatMessage("No active account selected. Use `uid <accountId>` first.");
+                    return true;
+
+                case "accounts":
+                    await ListAccounts(connection);
+                    return true;
+            }
+
+            return false;
+        }
+
+        private static async Task InitializeTargetAccount(ConsoleClientConnection connection)
+        {
+            if (connection.AccountServerId > 0 && await TryGetCurrentAccount(connection) is not null)
+            {
+                await connection.SendChatMessage($"Console default account: UID {connection.AccountServerId}");
+                return;
+            }
+
+            using var context = await connection.Context.CreateDbContextAsync();
+            var firstAccount = await context.Accounts
+                .OrderBy(x => x.ServerId)
+                .FirstOrDefaultAsync();
+
+            if (firstAccount == null)
+            {
+                connection.AccountServerId = 0;
+                await connection.SendChatMessage("No account found yet. Create/login an account first, then use `uid <accountId>`.");
+                return;
+            }
+
+            connection.AccountServerId = firstAccount.ServerId;
+            await connection.SendChatMessage($"Console auto-selected account: UID {firstAccount.ServerId}, Nickname: {firstAccount.Nickname}, Level: {firstAccount.Level}");
+        }
+
+        private static async Task<bool> EnsureTargetAccountSelected(ConsoleClientConnection connection)
+        {
+            if (await TryGetCurrentAccount(connection) is not null)
+                return true;
+
+            await connection.SendChatMessage("No valid account selected. Use `accounts` to list accounts, then `uid <accountId>` to select one.");
+            return false;
+        }
+
+        private static async Task SelectTargetAccount(ConsoleClientConnection connection, long accountId)
+        {
+            using var context = await connection.Context.CreateDbContextAsync();
+            var account = await context.Accounts.FirstOrDefaultAsync(x => x.ServerId == accountId);
+            if (account == null)
+            {
+                await connection.SendChatMessage($"Account {accountId} not found.");
+                return;
+            }
+
+            connection.AccountServerId = account.ServerId;
+            await connection.SendChatMessage($"Switched console target account to UID {account.ServerId}, Nickname: {account.Nickname}, Level: {account.Level}");
+        }
+
+        private static async Task<AccountDBServer?> TryGetCurrentAccount(ConsoleClientConnection connection)
+        {
+            if (connection.AccountServerId <= 0)
+                return null;
+
+            using var context = await connection.Context.CreateDbContextAsync();
+            return await context.Accounts.FirstOrDefaultAsync(x => x.ServerId == connection.AccountServerId);
+        }
+
+        private static async Task ListAccounts(ConsoleClientConnection connection)
+        {
+            using var context = await connection.Context.CreateDbContextAsync();
+            var accounts = await context.Accounts
+                .OrderBy(x => x.ServerId)
+                .Take(20)
+                .Select(x => new { x.ServerId, x.Nickname, x.Level })
+                .ToListAsync();
+
+            if (accounts.Count == 0)
+            {
+                await connection.SendChatMessage("No accounts found.");
+                return;
+            }
+
+            await connection.SendChatMessage("Accounts:");
+            foreach (var account in accounts)
+            {
+                await connection.SendChatMessage($"  UID {account.ServerId} | Lv {account.Level} | {account.Nickname}");
             }
         }
     }

--- a/Shittim-Server/Services/ClientMetadataPatchService.cs
+++ b/Shittim-Server/Services/ClientMetadataPatchService.cs
@@ -11,9 +11,9 @@ namespace Shittim_Server.Services
 
         private static readonly MetadataChunk[] MetadataChunks =
         [
-            new(0x145D428, 0),
-            new(0xFA6650, 1),
-            new(0x145D368, 2)
+            new(0x145D800, 0),
+            new(0xFA6A28, 1),
+            new(0x145D740, 2)
         ];
 
         private static readonly JsonSerializerOptions JsonOptions = new()

--- a/Shittim-Server/Shittim-Server.csproj
+++ b/Shittim-Server/Shittim-Server.csproj
@@ -6,6 +6,11 @@
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
 
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <DebugSymbols>false</DebugSymbols>
+    <DebugType>none</DebugType>
+  </PropertyGroup>
+
   <ItemGroup>
     <None Include="..\.editorconfig" Link=".editorconfig" />
   </ItemGroup>

--- a/Shittim-Server/Utils/ConsoleHelper.cs
+++ b/Shittim-Server/Utils/ConsoleHelper.cs
@@ -14,6 +14,8 @@ namespace Shittim.Utils
     ///    console output**.  Because ASP.NET request-handling threads write
     ///    log lines through <c>Console.WriteLine</c>, every request-handling
     ///    thread blocks until the user presses Escape – freezing the server.
+    ///    This is now opt-in because disabling QuickEdit also removes the
+    ///    normal mouse selection / scroll behaviour in a regular terminal.
     ///
     /// 2. **Stdout pipe buffer saturation** (GUI launcher / piped output)
     ///    When the server is spawned as a child process whose stdout is a
@@ -47,12 +49,13 @@ namespace Shittim.Utils
         /// </summary>
         public static void Harden()
         {
-            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+            if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows) && ShouldDisableQuickEdit())
             {
                 DisableQuickEditMode();
             }
 
-            InstallAsyncConsoleWriter();
+            if (ShouldInstallAsyncConsoleWriter())
+                InstallAsyncConsoleWriter();
         }
 
         // ── QuickEdit ──────────────────────────────────────────────────
@@ -80,6 +83,24 @@ namespace Shittim.Utils
         }
 
         // ── Async Console.Out ──────────────────────────────────────────
+
+        private static bool ShouldDisableQuickEdit()
+        {
+            return ReadBoolEnvironmentVariable("SHITTIM_DISABLE_QUICK_EDIT", defaultValue: false);
+        }
+
+        private static bool ShouldInstallAsyncConsoleWriter()
+        {
+            // Keep the async writer for piped / GUI-hosted runs where stdout can block,
+            // but preserve native console colour and line discipline in a real terminal.
+            return ReadBoolEnvironmentVariable("SHITTIM_ASYNC_CONSOLE_WRITER", Console.IsOutputRedirected);
+        }
+
+        private static bool ReadBoolEnvironmentVariable(string name, bool defaultValue)
+        {
+            var value = Environment.GetEnvironmentVariable(name);
+            return bool.TryParse(value, out var parsed) ? parsed : defaultValue;
+        }
 
         private static void InstallAsyncConsoleWriter()
         {


### PR DESCRIPTION
Update client metadata patch addresses to match the current client layout, fixing gateway payload decode failures caused by incorrect patched metadata.

Also improve local console GM command handling, make console hardening opt-in for interactive terminals, add a Visual Studio solution file, and disable debug symbol output for Release builds.