### PR TITLE
bug(momotalk,shop,event): fix stuck conversations, lost buys, and reward-path crashes

### DIFF
--- a/Schale/Data/GameModel/ProgressModel/MomoTalkOutLineDB.cs
+++ b/Schale/Data/GameModel/ProgressModel/MomoTalkOutLineDB.cs
@@ -18,6 +18,13 @@ namespace Schale.Data.GameModel
         public long CharacterDBId { get; set; }
         public long CharacterId { get; set; }
         public long LatestMessageGroupId { get; set; }
+
+        // Set when a MomoTalk_Read stopped because the next group opens with a FavorRankUp gate the student has
+        // not reached. LatestMessageGroupId alone cannot distinguish that state from "next unread group", and
+        // the login sync must not advance an unread group - that would skip its story.
+        [JsonIgnore]
+        public long? PendingGateGroupId { get; set; }
+
         public long? ChosenMessageId { get; set; }
         public List<long> ScheduleIds { get; set; } = [];
         public DateTime LastUpdateDate { get; set; }

--- a/Shittim-Server.Tests/MomoTalkConversationChainTests.cs
+++ b/Shittim-Server.Tests/MomoTalkConversationChainTests.cs
@@ -53,6 +53,34 @@ public class MomoTalkConversationChainTests
         Assert.Equal(0, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040100, favorRank: 99));
     }
 
+    [Fact]
+    public void APendingGateOpensOnceTheRankIsThere()
+    {
+        // MomoTalk_Read stopped at 100040020 because 100040090 needs rank 3.
+        Assert.Equal(0, MomoTalkService.ResumeGroup(
+            Messengers, currentGroupId: 100040020, pendingGateGroupId: 100040090, currentGroupWasRead: true, favorRank: 2));
+        Assert.Equal(100040090, MomoTalkService.ResumeGroup(
+            Messengers, currentGroupId: 100040020, pendingGateGroupId: 100040090, currentGroupWasRead: true, favorRank: 3));
+    }
+
+    [Fact]
+    public void AnUnreadGroupIsNeverSkippedBySync()
+    {
+        // The outline points at 100040020 as the NEXT unread group (set by reading 100040011); the player already
+        // has rank 3, so 100040090's gate is open - but advancing would skip 100040020's unread messages.
+        Assert.Equal(0, MomoTalkService.ResumeGroup(
+            Messengers, currentGroupId: 100040020, pendingGateGroupId: null, currentGroupWasRead: false, favorRank: 3));
+    }
+
+    [Fact]
+    public void ALegacyRowResumesPastTheGateOnlyWithProofItWasRead()
+    {
+        // Rows written before the pending-gate marker existed: a recorded choice for the current group is the
+        // proof that it was read and the stop really was the gate.
+        Assert.Equal(100040090, MomoTalkService.ResumeGroup(
+            Messengers, currentGroupId: 100040020, pendingGateGroupId: null, currentGroupWasRead: true, favorRank: 3));
+    }
+
     private static AcademyMessangerExcelT Row(
         long id,
         long group,

--- a/Shittim-Server.Tests/MomoTalkConversationChainTests.cs
+++ b/Shittim-Server.Tests/MomoTalkConversationChainTests.cs
@@ -1,0 +1,70 @@
+using BlueArchiveAPI.Services;
+using Schale.FlatData;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+public class MomoTalkConversationChainTests
+{
+    // Shaped after the live AcademyMessangerExcel rows for character 10004: groups are numbered in reading order and
+    // chained end to end by NextGroupId, and a new conversation is marked by a FavorRankUp condition on the first
+    // row of the group it starts at (100040010 at rank 2, 100040090 at rank 3).
+    private static readonly List<AcademyMessangerExcelT> Messengers =
+    [
+        Row(id: 1, group: 100040010, next: 100040011, condition: AcademyMessageConditions.FavorRankUp, conditionValue: 2),
+        Row(id: 1, group: 100040011, next: 100040020),
+        Row(id: 1, group: 100040020, next: 100040090),
+        Row(id: 1, group: 100040090, next: 100040100, condition: AcademyMessageConditions.FavorRankUp, conditionValue: 3),
+        Row(id: 2, group: 100040090, next: 100040100),
+        Row(id: 1, group: 100040100, next: 0),
+    ];
+
+    [Fact]
+    public void AStudentOpensOnTheirLowestGroupOnceItsRankIsReached()
+    {
+        Assert.Equal(0, MomoTalkService.OpeningGroup(Messengers, characterId: 10004, favorRank: 1));
+        Assert.Equal(100040010, MomoTalkService.OpeningGroup(Messengers, characterId: 10004, favorRank: 2));
+    }
+
+    [Fact]
+    public void AnotherStudentGetsNothing()
+    {
+        Assert.Equal(0, MomoTalkService.OpeningGroup(Messengers, characterId: 20000, favorRank: 99));
+    }
+
+    [Fact]
+    public void AConversationStoppedAtARankGateResumesOnceTheRankIsThere()
+    {
+        Assert.Equal(0, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040020, favorRank: 2));
+        Assert.Equal(100040090, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040020, favorRank: 3));
+    }
+
+    [Fact]
+    public void AnOrdinaryContinuationIsLeftToTheClient()
+    {
+        // 100040011 follows 100040010 with no gate, so the player reads their way to it through MomoTalk_Read;
+        // pushing it here would spill messages they have not reached.
+        Assert.Equal(0, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040010, favorRank: 99));
+    }
+
+    [Fact]
+    public void TheLastGroupHasNothingAfterIt()
+    {
+        Assert.Equal(0, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040100, favorRank: 99));
+    }
+
+    private static AcademyMessangerExcelT Row(
+        long id,
+        long group,
+        long next,
+        AcademyMessageConditions condition = AcademyMessageConditions.None,
+        long conditionValue = 0) => new()
+        {
+            Id = id,
+            MessageGroupId = group,
+            CharacterId = 10004,
+            NextGroupId = next,
+            MessageCondition = condition,
+            ConditionValue = conditionValue
+        };
+}

--- a/Shittim-Server.Tests/MomoTalkShippedDataTests.cs
+++ b/Shittim-Server.Tests/MomoTalkShippedDataTests.cs
@@ -8,14 +8,25 @@ namespace Shittim_Server.Tests;
 // AcademyMessangerExcel, so the assumptions they encode - the opening group is the lowest id, its FavorRankUp
 // gate is on the first row, follow-up conversations hang off NextGroupId behind a rank gate - stay checked
 // against the shipped table rather than against my reading of it.
-// Skipped when no ExcelDB.db is available (CI, or a checkout without the client data).
+// Skipped when no ExcelDB.db is available (CI, or a checkout without the client data). The skip is decided by
+// the attribute so the runner reports these as skipped rather than green-while-asserting-nothing; a present but
+// unreadable database (rotated SQLCipher key) fails instead of passing silently.
 public class MomoTalkShippedDataTests
 {
-    [Fact]
+    private sealed class ShippedDataFactAttribute : FactAttribute
+    {
+        public ShippedDataFactAttribute()
+        {
+            var dumped = DumpedDir();
+            if (dumped == null || !File.Exists(Path.Combine(dumped, "ExcelDB.db")))
+                Skip = "Shipped ExcelDB.db not available in this checkout";
+        }
+    }
+
+    [ShippedDataFact]
     public void EveryStudentsConversationOpensAtTheLowestGroupBehindItsRankGate()
     {
         var messengers = ShippedMessengers();
-        if (messengers == null) return;
 
         var students = messengers.Where(x => x.CharacterId > 0).GroupBy(x => x.CharacterId).ToList();
         Assert.NotEmpty(students);
@@ -37,12 +48,11 @@ public class MomoTalkShippedDataTests
         }
     }
 
-    [Fact]
+    [ShippedDataFact]
     public void ARankGateIsAlwaysTheFirstRowOfTheGroupItGates()
     {
         // RankUnlockedGroup and the handler's own gate both read the condition off the group's opening row.
         var messengers = ShippedMessengers();
-        if (messengers == null) return;
 
         foreach (var group in messengers.GroupBy(x => x.MessageGroupId))
         {
@@ -52,11 +62,10 @@ public class MomoTalkShippedDataTests
         }
     }
 
-    [Fact]
+    [ShippedDataFact]
     public void AStudentsConversationsAreReachableOneRankGateAtATime()
     {
         var messengers = ShippedMessengers();
-        if (messengers == null) return;
 
         var student = messengers.Where(x => x.CharacterId > 0).GroupBy(x => x.CharacterId).OrderBy(x => x.Key).First();
 
@@ -92,26 +101,31 @@ public class MomoTalkShippedDataTests
         Assert.True(gatesCrossed > 0, "expected at least one rank-gated conversation on the sample student");
     }
 
-    private static List<AcademyMessangerExcelT>? ShippedMessengers()
+    private static string? DumpedDir()
     {
         var dir = AppContext.BaseDirectory;
         while (dir != null && !Directory.Exists(Path.Combine(dir, "Shittim-Server")))
             dir = Path.GetDirectoryName(dir);
 
-        var dumped = new[]
-        {
-            Path.Combine(dir!, "Shittim-Server", "Resources", "Dumped"),
-            Path.Combine(dir!, "Shittim-Server", "bin", "Debug", "net10.0", "Resources", "Dumped"),
-            Path.Combine(dir!, "Shittim-Server", "bin", "Release", "net10.0", "Resources", "Dumped"),
-        }.FirstOrDefault(Directory.Exists);
-
-        if (dumped == null)
+        if (dir == null)
             return null;
 
-        ExcelTableService.DumpedDir = dumped;
+        return new[]
+        {
+            Path.Combine(dir, "Shittim-Server", "Resources", "Dumped"),
+            Path.Combine(dir, "Shittim-Server", "bin", "Debug", "net10.0", "Resources", "Dumped"),
+            Path.Combine(dir, "Shittim-Server", "bin", "Release", "net10.0", "Resources", "Dumped"),
+        }.FirstOrDefault(Directory.Exists);
+    }
 
-        // Empty means the table degraded - no ExcelDB.db, or a SQLCipher key that has rotated.
+    private static List<AcademyMessangerExcelT> ShippedMessengers()
+    {
+        ExcelTableService.DumpedDir = DumpedDir()!;
+
+        // Empty means the table degraded - the SQLCipher key rotated or the dump is truncated. The attribute
+        // already skipped when the file is absent, so degradation here is a failure, not a skip.
         var messengers = new ExcelTableService().GetTable<AcademyMessangerExcelT>();
-        return messengers.Count > 0 ? messengers : null;
+        Assert.NotEmpty(messengers);
+        return messengers;
     }
 }

--- a/Shittim-Server.Tests/MomoTalkShippedDataTests.cs
+++ b/Shittim-Server.Tests/MomoTalkShippedDataTests.cs
@@ -1,0 +1,117 @@
+using BlueArchiveAPI.Services;
+using Schale.FlatData;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+// The chaining tests next door run on a hand-built fixture. These run the same two functions over the real
+// AcademyMessangerExcel, so the assumptions they encode - the opening group is the lowest id, its FavorRankUp
+// gate is on the first row, follow-up conversations hang off NextGroupId behind a rank gate - stay checked
+// against the shipped table rather than against my reading of it.
+// Skipped when no ExcelDB.db is available (CI, or a checkout without the client data).
+public class MomoTalkShippedDataTests
+{
+    [Fact]
+    public void EveryStudentsConversationOpensAtTheLowestGroupBehindItsRankGate()
+    {
+        var messengers = ShippedMessengers();
+        if (messengers == null) return;
+
+        var students = messengers.Where(x => x.CharacterId > 0).GroupBy(x => x.CharacterId).ToList();
+        Assert.NotEmpty(students);
+
+        foreach (var student in students)
+        {
+            var groups = student.GroupBy(x => x.MessageGroupId).ToDictionary(g => g.Key, g => g.OrderBy(x => x.Id).ToList());
+            var lowest = groups.Keys.Min();
+
+            // Nothing points at the opening group, so it is the one to seed an outline with.
+            var incoming = student.Where(x => x.NextGroupId > 0).Select(x => x.NextGroupId).ToHashSet();
+            Assert.Equal([lowest], groups.Keys.Where(k => !incoming.Contains(k)).OrderBy(k => k).ToList());
+
+            // Its gate decides whether the student has a conversation at all yet.
+            var gate = groups[lowest][0];
+            Assert.Equal(AcademyMessageConditions.FavorRankUp, gate.MessageCondition);
+            Assert.Equal(0, MomoTalkService.OpeningGroup(messengers, student.Key, gate.ConditionValue - 1));
+            Assert.Equal(lowest, MomoTalkService.OpeningGroup(messengers, student.Key, gate.ConditionValue));
+        }
+    }
+
+    [Fact]
+    public void ARankGateIsAlwaysTheFirstRowOfTheGroupItGates()
+    {
+        // RankUnlockedGroup and the handler's own gate both read the condition off the group's opening row.
+        var messengers = ShippedMessengers();
+        if (messengers == null) return;
+
+        foreach (var group in messengers.GroupBy(x => x.MessageGroupId))
+        {
+            var rows = group.OrderBy(x => x.Id).ToList();
+            if (rows.Any(x => x.MessageCondition == AcademyMessageConditions.FavorRankUp))
+                Assert.Equal(AcademyMessageConditions.FavorRankUp, rows[0].MessageCondition);
+        }
+    }
+
+    [Fact]
+    public void AStudentsConversationsAreReachableOneRankGateAtATime()
+    {
+        var messengers = ShippedMessengers();
+        if (messengers == null) return;
+
+        var student = messengers.Where(x => x.CharacterId > 0).GroupBy(x => x.CharacterId).OrderBy(x => x.Key).First();
+
+        var group = MomoTalkService.OpeningGroup(messengers, student.Key, 99);
+        Assert.NotEqual(0, group);
+
+        var gatesCrossed = 0;
+        for (var step = 0; step < 500; step++)
+        {
+            var next = messengers
+                .Where(x => x.MessageGroupId == group && x.NextGroupId > 0 && x.NextGroupId != group)
+                .Select(x => x.NextGroupId)
+                .FirstOrDefault();
+            if (next == 0) break;
+
+            // Every gate on the way is one the old code stopped at for good; RankUnlockedGroup has to find each.
+            var opening = messengers.Where(x => x.MessageGroupId == next).OrderBy(x => x.Id).First();
+            if (opening.MessageCondition == AcademyMessageConditions.FavorRankUp)
+            {
+                Assert.Equal(next, MomoTalkService.RankUnlockedGroup(messengers, group, 99));
+                Assert.Equal(0, MomoTalkService.RankUnlockedGroup(messengers, group, opening.ConditionValue - 1));
+                gatesCrossed++;
+            }
+            else
+            {
+                // An ordinary continuation is the client's job, never pushed from here.
+                Assert.Equal(0, MomoTalkService.RankUnlockedGroup(messengers, group, 99));
+            }
+
+            group = next;
+        }
+
+        Assert.True(gatesCrossed > 0, "expected at least one rank-gated conversation on the sample student");
+    }
+
+    private static List<AcademyMessangerExcelT>? ShippedMessengers()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !Directory.Exists(Path.Combine(dir, "Shittim-Server")))
+            dir = Path.GetDirectoryName(dir);
+
+        var dumped = new[]
+        {
+            Path.Combine(dir!, "Shittim-Server", "Resources", "Dumped"),
+            Path.Combine(dir!, "Shittim-Server", "bin", "Debug", "net10.0", "Resources", "Dumped"),
+            Path.Combine(dir!, "Shittim-Server", "bin", "Release", "net10.0", "Resources", "Dumped"),
+        }.FirstOrDefault(Directory.Exists);
+
+        if (dumped == null)
+            return null;
+
+        ExcelTableService.DumpedDir = dumped;
+
+        // Empty means the table degraded - no ExcelDB.db, or a SQLCipher key that has rotated.
+        var messengers = new ExcelTableService().GetTable<AcademyMessangerExcelT>();
+        return messengers.Count > 0 ? messengers : null;
+    }
+}

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+public class ProtocolRegistrationTests
+{
+    // An unregistered protocol is answered with ServerFailedToHandleRequest, which the client shows as
+    // "Server failed to process request. Returning to the title screen." These are the ones a normal session
+    // cannot get past, so a handler going missing should fail here rather than in someone's play session.
+    [Theory]
+    [InlineData(Protocol.Scenario_Enter)]
+    [InlineData(Protocol.Scenario_GroupHistoryUpdate)]
+    [InlineData(Protocol.Scenario_Clear)]
+    [InlineData(Protocol.MomoTalk_OutLine)]
+    [InlineData(Protocol.MomoTalk_Read)]
+    [InlineData(Protocol.MomoTalk_FavorSchedule)]
+    [InlineData(Protocol.Shop_BuyMerchandise)]
+    [InlineData(Protocol.Mission_Reward)]
+    [InlineData(Protocol.Mission_MultipleReward)]
+    [InlineData(Protocol.Craft_List)]
+    [InlineData(Protocol.Craft_SelectNode)]
+    public void TheProtocolHasAHandler(Protocol protocol)
+    {
+        Assert.Contains(protocol, HandledProtocols);
+    }
+
+    private static readonly HashSet<Protocol> HandledProtocols = typeof(ProtocolHandlerBase).Assembly
+        .GetTypes()
+        .Where(t => t.IsClass && !t.IsAbstract && t.IsAssignableTo(typeof(ProtocolHandlerBase)))
+        .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        .SelectMany(m => m.GetCustomAttributes<ProtocolHandlerAttribute>())
+        .Select(a => a.Protocol)
+        .Where(p => p != Protocol.None)
+        .ToHashSet();
+}

--- a/Shittim-Server.Tests/ShopPurchaseLimitTests.cs
+++ b/Shittim-Server.Tests/ShopPurchaseLimitTests.cs
@@ -12,15 +12,22 @@ namespace Shittim_Server.Tests;
 public class ShopPurchaseLimitTests
 {
     [Theory]
-    [InlineData(0)]
     [InlineData(-1)]
     [InlineData(-30)]
     [InlineData(long.MinValue)]
-    public void ANonPositiveCountIsRefused(long count)
+    public void ANegativeCountIsRefused(long count)
     {
-        // A non-positive count is what inverted the consume into a grant.
-        var ex = Assert.Throws<WebAPIException>(() => ShopHandler.ValidatePurchaseCount(count));
+        // A negative count is what inverted the consume into a grant.
+        var ex = Assert.Throws<WebAPIException>(() => ShopHandler.NormalizePurchaseCount(count));
         Assert.Equal(WebAPIErrorCode.ShopInvalidCostOrReward, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void AnAbsentCountBuysOne()
+    {
+        // A request that omits PurchaseCount deserializes to 0. Refusing it made single-unit buys fail with
+        // ShopInvalidCostOrReward while the same item bought in bulk went through.
+        Assert.Equal(1, ShopHandler.NormalizePurchaseCount(0));
     }
 
     [Theory]
@@ -29,8 +36,8 @@ public class ShopPurchaseLimitTests
     [InlineData(ShopHandler.MaxPurchaseCountPerRequest + 1)]
     public void ACountBigEnoughToOverflowTheCostIsRefused(long count)
     {
-        // The bound has to be two-sided: `> 0` alone still allows a count large enough that cost * count overflows to a negative number, which re-opens the same hole.
-        var ex = Assert.Throws<WebAPIException>(() => ShopHandler.ValidatePurchaseCount(count));
+        // The bound has to be two-sided: `>= 0` alone still allows a count large enough that cost * count overflows to a negative number, which re-opens the same hole.
+        var ex = Assert.Throws<WebAPIException>(() => ShopHandler.NormalizePurchaseCount(count));
         Assert.Equal(WebAPIErrorCode.ShopInvalidCostOrReward, ex.ErrorCode);
     }
 
@@ -41,7 +48,7 @@ public class ShopPurchaseLimitTests
     [InlineData(ShopHandler.MaxPurchaseCountPerRequest)]
     public void RealisticCountsPass(long count)
     {
-        ShopHandler.ValidatePurchaseCount(count);
+        Assert.Equal(count, ShopHandler.NormalizePurchaseCount(count));
     }
 
     [Fact]

--- a/Shittim-Server/Commands/CharacterCommand.cs
+++ b/Shittim-Server/Commands/CharacterCommand.cs
@@ -104,8 +104,9 @@ namespace Shittim.Commands
                 case "modify":
                     if (Target == "all")
                     {
+                        // ModifyAllCharacters messages success or failure itself; a second unconditional
+                        // "Modified All Characters" here reported success even when the input was rejected.
                         await CharacterGM.ModifyAllCharacters(connection, Options, ModifyParams);
-                        await connection.SendChatMessage("Modified All Characters");
                     }
                     else if (isValidId)
                     {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -448,6 +448,11 @@ public class AccountHandler : ProtocolHandlerBase
             AccountClanMemberDB = new ClanMemberDB { AccountId = account.ServerId }
         };
 
+        // The client caches this list for the MomoTalk screen, so a student without a row here has no conversation
+        // to open until the next login.
+        MomoTalkService.SyncOutlines(db, account, _excelService.GetTable<AcademyMessangerExcelT>());
+        await db.SaveChangesAsync();
+
         var momoTalkOutlines = db.GetAccountMomoTalkOutLines(account.ServerId).ToList();
         response.MomotalkOutlineResponse = new MomoTalkOutLineResponse
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
@@ -144,7 +144,13 @@ public class EventContentHandler : ProtocolHandlerBase
         .ToList();
 
     private static int ShortestColumn(int? a, int? b, int? c)
-        => Math.Min(a ?? 0, Math.Min(b ?? 0, c ?? 0));
+    {
+        var counts = new[] { a ?? 0, b ?? 0, c ?? 0 };
+        if (counts.Distinct().Count() != 1)
+            throw new WebAPIException(WebAPIErrorCode.ShopInvalidCostOrReward,
+                $"Ragged parcel columns: types={counts[0]}, ids={counts[1]}, amounts={counts[2]}");
+        return counts[0];
+    }
 
     [ProtocolHandler(Protocol.EventContent_ReceiveStageTotalReward)]
     public async Task<EventContentReceiveStageTotalRewardResponse> ReceiveStageTotalReward(

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
@@ -65,7 +65,7 @@ public class EventContentHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
-        ShopHandler.ValidatePurchaseCount(request.PurchaseCount);
+        var purchaseCount = ShopHandler.NormalizePurchaseCount(request.PurchaseCount);
 
         var shopExcel = EventShop(request.EventContentId).FirstOrDefault(x => x.Id == request.ShopUniqueId)
             ?? throw new WebAPIException(WebAPIErrorCode.ShopExcelNotFound, $"Shop {request.ShopUniqueId} not found");
@@ -74,21 +74,23 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {request.GoodsUniqueId} not found");
 
         var purchaseHistory = await ShopManager.EnsurePurchasable(
-            db, account, request.ShopUniqueId, shopExcel, request.PurchaseCount);
+            db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
+        // Indexed to the shortest of the three columns: a ragged goods row threw IndexOutOfRange, which the client
+        // only sees as the generic failure popup.
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < (goodsExcel.ConsumeParcelType?.Count ?? 0); i++)
+        for (int i = 0; i < ShortestColumn(goodsExcel.ConsumeParcelType?.Count, goodsExcel.ConsumeParcelId?.Count, goodsExcel.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(
                 goodsExcel.ConsumeParcelType![i],
                 goodsExcel.ConsumeParcelId![i],
-                goodsExcel.ConsumeParcelAmount![i] * request.PurchaseCount));
+                goodsExcel.ConsumeParcelAmount![i] * purchaseCount));
 
         var rewardParcels = new List<ParcelResult>();
-        for (int i = 0; i < (goodsExcel.ParcelType?.Count ?? 0); i++)
+        for (int i = 0; i < ShortestColumn(goodsExcel.ParcelType?.Count, goodsExcel.ParcelId?.Count, goodsExcel.ParcelAmount?.Count); i++)
             rewardParcels.Add(new ParcelResult(
                 goodsExcel.ParcelType![i],
                 goodsExcel.ParcelId![i],
-                goodsExcel.ParcelAmount![i] * request.PurchaseCount));
+                goodsExcel.ParcelAmount![i] * purchaseCount));
 
         if (consumeParcels.Count > 0)
             await _parcelHandler.BuildParcel(db, account, consumeParcels, isConsume: true);
@@ -101,7 +103,7 @@ public class EventContentHandler : ProtocolHandlerBase
 
         response.AccountCurrencyDB = db.GetAccountCurrencies(account.ServerId).FirstOrDefaultMapTo(_mapper);
 
-        purchaseHistory.PurchaseCount += request.PurchaseCount;
+        purchaseHistory.PurchaseCount += purchaseCount;
 
         response.ShopProductDB = new ShopProductDB
         {
@@ -140,6 +142,9 @@ public class EventContentHandler : ProtocolHandlerBase
             SalePeriodTo = ""
         })
         .ToList();
+
+    private static int ShortestColumn(int? a, int? b, int? c)
+        => Math.Min(a ?? 0, Math.Min(b ?? 0, c ?? 0));
 
     [ProtocolHandler(Protocol.EventContent_ReceiveStageTotalReward)]
     public async Task<EventContentReceiveStageTotalRewardResponse> ReceiveStageTotalReward(

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
@@ -76,17 +76,17 @@ public class EventContentHandler : ProtocolHandlerBase
         var purchaseHistory = await ShopManager.EnsurePurchasable(
             db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
-        // Indexed to the shortest of the three columns: a ragged goods row threw IndexOutOfRange, which the client
-        // only sees as the generic failure popup.
+        // Column lengths are validated up front: a ragged goods row used to throw IndexOutOfRange mid-purchase,
+        // and truncating instead silently undercharged or dropped rewards.
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < ShortestColumn(goodsExcel.ConsumeParcelType?.Count, goodsExcel.ConsumeParcelId?.Count, goodsExcel.ConsumeParcelAmount?.Count); i++)
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(goodsExcel.ConsumeParcelType?.Count, goodsExcel.ConsumeParcelId?.Count, goodsExcel.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(
                 goodsExcel.ConsumeParcelType![i],
                 goodsExcel.ConsumeParcelId![i],
                 goodsExcel.ConsumeParcelAmount![i] * purchaseCount));
 
         var rewardParcels = new List<ParcelResult>();
-        for (int i = 0; i < ShortestColumn(goodsExcel.ParcelType?.Count, goodsExcel.ParcelId?.Count, goodsExcel.ParcelAmount?.Count); i++)
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(goodsExcel.ParcelType?.Count, goodsExcel.ParcelId?.Count, goodsExcel.ParcelAmount?.Count); i++)
             rewardParcels.Add(new ParcelResult(
                 goodsExcel.ParcelType![i],
                 goodsExcel.ParcelId![i],
@@ -142,15 +142,6 @@ public class EventContentHandler : ProtocolHandlerBase
             SalePeriodTo = ""
         })
         .ToList();
-
-    private static int ShortestColumn(int? a, int? b, int? c)
-    {
-        var counts = new[] { a ?? 0, b ?? 0, c ?? 0 };
-        if (counts.Distinct().Count() != 1)
-            throw new WebAPIException(WebAPIErrorCode.ShopInvalidCostOrReward,
-                $"Ragged parcel columns: types={counts[0]}, ids={counts[1]}, amounts={counts[2]}");
-        return counts[0];
-    }
 
     [ProtocolHandler(Protocol.EventContent_ReceiveStageTotalReward)]
     public async Task<EventContentReceiveStageTotalRewardResponse> ReceiveStageTotalReward(
@@ -332,7 +323,7 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {manage.GoodsId} not found");
 
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i] * drawCount));
 
         var shopRows = _excelService.GetTable<EventContentBoxGachaShopExcelT>()
@@ -353,7 +344,7 @@ public class EventContentHandler : ProtocolHandlerBase
                 if (goods == null)
                     continue;
 
-                for (int i = 0; i < ShortestColumn(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
+                for (int i = 0; i < ShopHandler.AlignedColumnCount(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
                 {
                     elementRewards.AddRange(ParcelInfo.CreateParcelInfo(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
                     rewardParcels.Add(new ParcelResult(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
@@ -571,7 +562,7 @@ public class EventContentHandler : ProtocolHandlerBase
             var costGoods = goodsTable.FirstOrDefault(x => x.Id == card.CostGoodsId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {card.CostGoodsId} not found");
 
-            for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
+            for (int i = 0; i < ShopHandler.AlignedColumnCount(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
                 consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i]));
 
             var rewards = new List<ParcelInfo>();
@@ -685,7 +676,7 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {drawn.CostGoodsId} not found");
 
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i]));
 
         var rewardParcels = new List<ParcelResult>();
@@ -768,10 +759,10 @@ public class EventContentHandler : ProtocolHandlerBase
             var goods = goodsTable.FirstOrDefault(x => x.Id == row.GoodsId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {row.GoodsId} not found");
 
-            for (int i = 0; i < ShortestColumn(goods.ConsumeParcelType?.Count, goods.ConsumeParcelId?.Count, goods.ConsumeParcelAmount?.Count); i++)
+            for (int i = 0; i < ShopHandler.AlignedColumnCount(goods.ConsumeParcelType?.Count, goods.ConsumeParcelId?.Count, goods.ConsumeParcelAmount?.Count); i++)
                 consumeParcels.Add(new ParcelResult(goods.ConsumeParcelType![i], goods.ConsumeParcelId![i], goods.ConsumeParcelAmount![i]));
 
-            for (int i = 0; i < ShortestColumn(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
+            for (int i = 0; i < ShopHandler.AlignedColumnCount(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
                 rewardParcels.Add(new ParcelResult(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
 
             play.RefreshShopIds.Remove(row.Id);

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
@@ -326,7 +326,7 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {manage.GoodsId} not found");
 
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < (costGoods.ConsumeParcelType?.Count ?? 0); i++)
+        for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i] * drawCount));
 
         var shopRows = _excelService.GetTable<EventContentBoxGachaShopExcelT>()
@@ -347,7 +347,7 @@ public class EventContentHandler : ProtocolHandlerBase
                 if (goods == null)
                     continue;
 
-                for (int i = 0; i < (goods.ParcelType?.Count ?? 0); i++)
+                for (int i = 0; i < ShortestColumn(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
                 {
                     elementRewards.AddRange(ParcelInfo.CreateParcelInfo(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
                     rewardParcels.Add(new ParcelResult(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
@@ -565,7 +565,7 @@ public class EventContentHandler : ProtocolHandlerBase
             var costGoods = goodsTable.FirstOrDefault(x => x.Id == card.CostGoodsId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {card.CostGoodsId} not found");
 
-            for (int i = 0; i < (costGoods.ConsumeParcelType?.Count ?? 0); i++)
+            for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
                 consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i]));
 
             var rewards = new List<ParcelInfo>();
@@ -679,7 +679,7 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {drawn.CostGoodsId} not found");
 
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < (costGoods.ConsumeParcelType?.Count ?? 0); i++)
+        for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i]));
 
         var rewardParcels = new List<ParcelResult>();
@@ -762,10 +762,10 @@ public class EventContentHandler : ProtocolHandlerBase
             var goods = goodsTable.FirstOrDefault(x => x.Id == row.GoodsId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {row.GoodsId} not found");
 
-            for (int i = 0; i < (goods.ConsumeParcelType?.Count ?? 0); i++)
+            for (int i = 0; i < ShortestColumn(goods.ConsumeParcelType?.Count, goods.ConsumeParcelId?.Count, goods.ConsumeParcelAmount?.Count); i++)
                 consumeParcels.Add(new ParcelResult(goods.ConsumeParcelType![i], goods.ConsumeParcelId![i], goods.ConsumeParcelAmount![i]));
 
-            for (int i = 0; i < (goods.ParcelType?.Count ?? 0); i++)
+            for (int i = 0; i < ShortestColumn(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
                 rewardParcels.Add(new ParcelResult(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
 
             play.RefreshShopIds.Remove(row.Id);

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentPlayHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentPlayHandler.cs
@@ -41,7 +41,8 @@ public class EventContentPlayHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {goodsId} not found");
 
         var cost = new List<ParcelResult>();
-        for (int i = 0; i < (goods.ConsumeParcelType?.Count ?? 0); i++)
+        var costCount = new[] { goods.ConsumeParcelType?.Count ?? 0, goods.ConsumeParcelId?.Count ?? 0, goods.ConsumeParcelAmount?.Count ?? 0 }.Min();
+        for (int i = 0; i < costCount; i++)
             cost.Add(new ParcelResult(goods.ConsumeParcelType![i], goods.ConsumeParcelId![i], goods.ConsumeParcelAmount![i] * multiplier));
 
         return cost;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentPlayHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentPlayHandler.cs
@@ -41,7 +41,8 @@ public class EventContentPlayHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {goodsId} not found");
 
         var cost = new List<ParcelResult>();
-        var costCount = new[] { goods.ConsumeParcelType?.Count ?? 0, goods.ConsumeParcelId?.Count ?? 0, goods.ConsumeParcelAmount?.Count ?? 0 }.Min();
+        var costCount = ShopHandler.AlignedColumnCount(
+            goods.ConsumeParcelType?.Count, goods.ConsumeParcelId?.Count, goods.ConsumeParcelAmount?.Count);
         for (int i = 0; i < costCount; i++)
             cost.Add(new ParcelResult(goods.ConsumeParcelType![i], goods.ConsumeParcelId![i], goods.ConsumeParcelAmount![i] * multiplier));
 

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
@@ -153,8 +153,12 @@ public class MomoTalkHandler : ProtocolHandlerBase
         // A FavorRankUp-gated group only opens once the student's relationship rank reaches the condition value; advancing past it regardless hands every story out at rank 1.
         if (nextGroupId > 0)
         {
+            // Ordered by Id, not table order: the condition sits on the group's opening row and only the dump
+            // happens to store them in that order.
             var nextGroupEntry = _academyMessengers
-                .FirstOrDefault(x => x.MessageGroupId == nextGroupId);
+                .Where(x => x.MessageGroupId == nextGroupId)
+                .OrderBy(x => x.Id)
+                .FirstOrDefault();
             if (nextGroupEntry != null
                 && nextGroupEntry.MessageCondition == AcademyMessageConditions.FavorRankUp
                 && favorRank < nextGroupEntry.ConditionValue)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
@@ -81,17 +81,27 @@ public class MomoTalkHandler : ProtocolHandlerBase
             var character = db.Characters.FirstOrDefault(c => c.ServerId == request.CharacterDBId && c.AccountServerId == account.ServerId);
             if (character == null) return response;
 
+            // LastReadMessageGroupId is 0 the first time a student is opened, and storing that leaves them with a
+            // conversation that can never start, so fall back to their first unlocked group.
+            var openingGroup = request.LastReadMessageGroupId > 0
+                ? request.LastReadMessageGroupId
+                : MomoTalkService.OpeningGroup(_academyMessengers, character.UniqueId, character.FavorRank);
+
             momotalkOutline = new MomoTalkOutLineDBServer
             {
                 AccountServerId = account.ServerId,
                 CharacterDBId = request.CharacterDBId,
                 CharacterId = character.UniqueId,
-                LatestMessageGroupId = request.LastReadMessageGroupId,
+                LatestMessageGroupId = openingGroup,
                 LastUpdateDate = account.GameSettings.ServerDateTime()
             };
             db.MomoTalkOutLines.Add(momotalkOutline);
             // Not saved here - the SaveChanges at the end of the handler bundles it.
         }
+
+        var favorRank = db.Characters
+            .FirstOrDefault(c => c.AccountServerId == account.ServerId
+                && c.ServerId == momotalkOutline.CharacterDBId)?.FavorRank ?? 1;
 
         long nextGroupId = 0;
         
@@ -146,13 +156,10 @@ public class MomoTalkHandler : ProtocolHandlerBase
             var nextGroupEntry = _academyMessengers
                 .FirstOrDefault(x => x.MessageGroupId == nextGroupId);
             if (nextGroupEntry != null
-                && nextGroupEntry.MessageCondition == AcademyMessageConditions.FavorRankUp)
+                && nextGroupEntry.MessageCondition == AcademyMessageConditions.FavorRankUp
+                && favorRank < nextGroupEntry.ConditionValue)
             {
-                var favorRank = db.Characters
-                    .FirstOrDefault(c => c.AccountServerId == account.ServerId
-                        && c.ServerId == momotalkOutline.CharacterDBId)?.FavorRank ?? 1;
-                if (favorRank < nextGroupEntry.ConditionValue)
-                    nextGroupId = 0;
+                nextGroupId = 0;
             }
         }
 
@@ -188,6 +195,9 @@ public class MomoTalkHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
+        MomoTalkService.SyncOutlines(db, account, _academyMessengers);
+        await db.SaveChangesAsync();
+
         var outlines = db.GetAccountMomoTalkOutLines(account.ServerId).ToList();
 
         response.MomoTalkOutLineDBs = _mapper.Map<List<MomoTalkOutLineDB>>(outlines);
@@ -208,23 +218,28 @@ public class MomoTalkHandler : ProtocolHandlerBase
         response.FavorScheduleRecords = MomoTalkService.GetAllFavorSchedules(outlines);
         response.ParcelResultDB = new();
 
-        var schedule = _academyFavorSchedules.GetScheduleById(request.ScheduleId);
-        if (schedule == null)
-            return response;
+        // Every one of these used to return an empty success, which the client reads as "reward accepted" while
+        // nothing was granted and nothing was spent. They are real refusals and have to reach the client as errors.
+        var schedule = _academyFavorSchedules.GetScheduleById(request.ScheduleId)
+            ?? throw new WebAPIException(WebAPIErrorCode.AcademyScheduleTableNotFound,
+                $"Favor schedule {request.ScheduleId} not found");
 
-        var targetOutline = outlines.FirstOrDefault(x => x.CharacterId == schedule.CharacterId);
-        if (targetOutline == null)
-            return response;
+        var targetOutline = outlines.FirstOrDefault(x => x.CharacterId == schedule.CharacterId)
+            ?? throw new WebAPIException(WebAPIErrorCode.AcademyRewardCharacterNotFound,
+                $"No MomoTalk outline for character {schedule.CharacterId}");
 
         if (targetOutline.ScheduleIds.Contains(request.ScheduleId))
-            return response;
+            throw new WebAPIException(WebAPIErrorCode.AcademyAlreadyAttendedFavorSchedule,
+                $"Favor schedule {request.ScheduleId} already attended");
 
         var accountCurrency = db.Currencies.FirstOrDefault(x => x.AccountServerId == account.ServerId);
-        if (accountCurrency == null)
-            return response;
-
-        if (!accountCurrency.CurrencyDict.TryGetValue(CurrencyTypes.AcademyTicket, out var currentTicket) || currentTicket <= 0)
-            return response;
+        if (accountCurrency == null
+            || !accountCurrency.CurrencyDict.TryGetValue(CurrencyTypes.AcademyTicket, out var currentTicket)
+            || currentTicket <= 0)
+        {
+            throw new WebAPIException(WebAPIErrorCode.AcademyTicketZero,
+                "No AcademyTicket available for a favor schedule");
+        }
 
         var parcelResults = new List<ParcelResult>
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
@@ -87,6 +87,11 @@ public class MomoTalkHandler : ProtocolHandlerBase
                 ? request.LastReadMessageGroupId
                 : MomoTalkService.OpeningGroup(_academyMessengers, character.UniqueId, character.FavorRank);
 
+            // A 0 here means the student has no messenger rows or their first group is still rank-locked;
+            // persisting it would recreate the stuck-conversation state this outline exists to avoid.
+            if (openingGroup == 0)
+                return response;
+
             momotalkOutline = new MomoTalkOutLineDBServer
             {
                 AccountServerId = account.ServerId,
@@ -163,6 +168,9 @@ public class MomoTalkHandler : ProtocolHandlerBase
                 && nextGroupEntry.MessageCondition == AcademyMessageConditions.FavorRankUp
                 && favorRank < nextGroupEntry.ConditionValue)
             {
+                // Remember where the conversation stopped so the login sync can resume it once the rank
+                // is reached - without this marker it cannot tell a gate-stop from an unread group.
+                momotalkOutline.PendingGateGroupId = nextGroupId;
                 nextGroupId = 0;
             }
         }
@@ -170,6 +178,7 @@ public class MomoTalkHandler : ProtocolHandlerBase
         if (nextGroupId > 0)
         {
             momotalkOutline.LatestMessageGroupId = nextGroupId;
+            momotalkOutline.PendingGateGroupId = null;
             momotalkOutline.LastUpdateDate = account.GameSettings.ServerDateTime();
             // Keep current outline choice null to prevent duplicate message bubbles.
             // Choice history is already represented by MomoTalkChoiceDBs.

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioHandler.cs
@@ -44,6 +44,21 @@ public class ScenarioHandler : ProtocolHandlerBase
         return response;
     }
 
+    // Entering a story episode. The response model carries nothing - the client plays the scenario from its own
+    // data and reports back through Scenario_GroupHistoryUpdate and Scenario_Clear - but the protocol still has to
+    // be answered: unregistered, the gateway replies ServerFailedToHandleRequest and the client drops to the title
+    // screen with "Server failed to process request", which is what final-story episodes did.
+    [ProtocolHandler(Protocol.Scenario_Enter)]
+    public async Task<ScenarioEnterResponse> Enter(
+        SchaleDataContext db,
+        ScenarioEnterRequest request,
+        ScenarioEnterResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Scenario_Skip)]
     public async Task<ScenarioSkipResponse> Skip(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ShopHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ShopHandler.cs
@@ -515,16 +515,33 @@ public class ShopHandler : ProtocolHandlerBase
             return purchaseCount;
 
         // Logged rather than silently coerced: if this line never appears in a play session, the 10009 popups on
-        // single-unit buys come from somewhere else and this reading was wrong.
-        Serilog.Log.Warning("Shop purchase arrived with no PurchaseCount; charging one unit");
+        // single-unit buys come from somewhere else and this reading was wrong. Information, not Warning - the
+        // client sends 0 on every single-unit buy, so this fires constantly in normal play.
+        Serilog.Log.Information("Shop purchase arrived with no PurchaseCount; charging one unit");
         return 1;
     }
 
-    /// <summary>Parcels for one goods row, scaled by the purchase count. Columns are indexed to the shortest of the three so a ragged excel row degrades instead of throwing.</summary>
+    /// <summary>
+    /// The common length of a goods row's three parcel columns. A ragged row used to throw IndexOutOfRange
+    /// mid-purchase; truncating to the shortest column instead silently undercharged or dropped rewards, so
+    /// unequal lengths are rejected before any parcel is applied.
+    /// </summary>
+    internal static int AlignedColumnCount(int? types, int? ids, int? amounts)
+    {
+        var t = types ?? 0;
+        var i = ids ?? 0;
+        var a = amounts ?? 0;
+        if (t != i || t != a)
+            throw new WebAPIException(WebAPIErrorCode.ShopInvalidCostOrReward,
+                $"Ragged goods parcel columns (types:{t} ids:{i} amounts:{a})");
+        return t;
+    }
+
+    /// <summary>Parcels for one goods row, scaled by the purchase count.</summary>
     private static List<ParcelInfo> BuildParcels(
         List<ParcelType>? types, List<long>? ids, List<long>? amounts, long purchaseCount)
     {
-        var count = Math.Min(types?.Count ?? 0, Math.Min(ids?.Count ?? 0, amounts?.Count ?? 0));
+        var count = AlignedColumnCount(types?.Count, ids?.Count, amounts?.Count);
 
         var parcels = new List<ParcelInfo>(count);
         for (int i = 0; i < count; i++)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ShopHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ShopHandler.cs
@@ -437,7 +437,7 @@ public class ShopHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
-        ValidatePurchaseCount(request.PurchaseCount);
+        var purchaseCount = NormalizePurchaseCount(request.PurchaseCount);
 
         var shopExcel = _excelService.GetTable<ShopExcelT>().FirstOrDefault(x => x.Id == request.ShopUniqueId);
         if (shopExcel == null)
@@ -448,35 +448,15 @@ public class ShopHandler : ProtocolHandlerBase
             throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {request.GoodsId} not found");
 
         var purchaseHistory = await ShopManager.EnsurePurchasable(
-            db, account, request.ShopUniqueId, shopExcel, request.PurchaseCount);
+            db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
-        var consumeParcelTypes = goodsExcel.ConsumeParcelType ?? [];
-        var consumeParcelIds = goodsExcel.ConsumeParcelId ?? [];
-        var consumeParcelAmounts = goodsExcel.ConsumeParcelAmount ?? [];
-
-        var rewardParcelTypes = goodsExcel.ParcelType ?? [];
-        var rewardParcelIds = goodsExcel.ParcelId ?? [];
-        var rewardParcelAmounts = goodsExcel.ParcelAmount ?? [];
-
-        var consumeParcels = new List<ParcelInfo>();
-        for (int i = 0; i < consumeParcelTypes.Count; i++)
-        {
-            consumeParcels.Add(new ParcelInfo
-            {
-                Key = new ParcelKeyPair { Type = consumeParcelTypes[i], Id = consumeParcelIds[i] },
-                Amount = consumeParcelAmounts[i] * request.PurchaseCount
-            });
-        }
-
-        var rewardParcels = new List<ParcelInfo>();
-        for (int i = 0; i < rewardParcelTypes.Count; i++)
-        {
-            rewardParcels.Add(new ParcelInfo
-            {
-                Key = new ParcelKeyPair { Type = rewardParcelTypes[i], Id = rewardParcelIds[i] },
-                Amount = rewardParcelAmounts[i] * request.PurchaseCount
-            });
-        }
+        // A goods row whose id/amount columns are shorter than its type column used to throw IndexOutOfRange out of
+        // these loops, which the client only ever sees as the generic failure popup (Shop_BuyRefreshMerchandise
+        // already indexes defensively for the same reason).
+        var consumeParcels = BuildParcels(
+            goodsExcel.ConsumeParcelType, goodsExcel.ConsumeParcelId, goodsExcel.ConsumeParcelAmount, purchaseCount);
+        var rewardParcels = BuildParcels(
+            goodsExcel.ParcelType, goodsExcel.ParcelId, goodsExcel.ParcelAmount, purchaseCount);
 
         if (consumeParcels.Count > 0)
         {
@@ -497,7 +477,7 @@ public class ShopHandler : ProtocolHandlerBase
             response.AccountCurrencyDB = accountCurrency.ToMap(_mapper);
         }
 
-        purchaseHistory.PurchaseCount += request.PurchaseCount;
+        purchaseHistory.PurchaseCount += purchaseCount;
 
         response.ShopProductDB = new ShopProductDB
         {
@@ -516,15 +496,47 @@ public class ShopHandler : ProtocolHandlerBase
         return response;
     }
 
-    // PurchaseCount arrives from the client and multiplies both the consume and the reward. A non-positive count inverts the consume into a grant (a -30-gem cost is credited, not debited), and a huge one overflows the int64 multiply back into negative territory, so the bound has to be two-sided.
+    // PurchaseCount arrives from the client and multiplies both the consume and the reward. A negative count inverts the consume into a grant (a -30-gem cost is credited, not debited), and a huge one overflows the int64 multiply back into negative territory, so the bound has to be two-sided.
     // The ceiling is far above any real shop's PurchaseCountLimit; per-shop limits are enforced separately in ShopManager.EnsurePurchasable.
     internal const long MaxPurchaseCountPerRequest = 10_000;
 
-    internal static void ValidatePurchaseCount(long purchaseCount)
+    /// <summary>
+    /// The count to actually charge and grant. An absent count deserializes to 0, and rejecting that made
+    /// single-unit buys fail with ShopInvalidCostOrReward while the same item bought in bulk went through;
+    /// a buy request means at least one. Negative and overflow-sized counts are still refused.
+    /// </summary>
+    internal static long NormalizePurchaseCount(long purchaseCount)
     {
-        if (purchaseCount is <= 0 or > MaxPurchaseCountPerRequest)
+        if (purchaseCount is < 0 or > MaxPurchaseCountPerRequest)
             throw new WebAPIException(WebAPIErrorCode.ShopInvalidCostOrReward,
                 $"Invalid purchase count {purchaseCount}");
+
+        if (purchaseCount > 0)
+            return purchaseCount;
+
+        // Logged rather than silently coerced: if this line never appears in a play session, the 10009 popups on
+        // single-unit buys come from somewhere else and this reading was wrong.
+        Serilog.Log.Warning("Shop purchase arrived with no PurchaseCount; charging one unit");
+        return 1;
+    }
+
+    /// <summary>Parcels for one goods row, scaled by the purchase count. Columns are indexed to the shortest of the three so a ragged excel row degrades instead of throwing.</summary>
+    private static List<ParcelInfo> BuildParcels(
+        List<ParcelType>? types, List<long>? ids, List<long>? amounts, long purchaseCount)
+    {
+        var count = Math.Min(types?.Count ?? 0, Math.Min(ids?.Count ?? 0, amounts?.Count ?? 0));
+
+        var parcels = new List<ParcelInfo>(count);
+        for (int i = 0; i < count; i++)
+        {
+            parcels.Add(new ParcelInfo
+            {
+                Key = new ParcelKeyPair { Type = types![i], Id = ids![i] },
+                Amount = amounts![i] * purchaseCount
+            });
+        }
+
+        return parcels;
     }
 
     [ProtocolHandler(Protocol.Shop_BuyRefreshMerchandise)]
@@ -639,7 +651,7 @@ public class ShopHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
-        ValidatePurchaseCount(request.PurchaseCount);
+        var purchaseCount = NormalizePurchaseCount(request.PurchaseCount);
 
         var shopExcel = _excelService.GetTable<ShopExcelT>().FirstOrDefault(x => x.Id == request.ShopUniqueId);
         if (shopExcel == null)
@@ -650,27 +662,12 @@ public class ShopHandler : ProtocolHandlerBase
             throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {request.GoodsUniqueId} not found");
 
         var purchaseHistory = await ShopManager.EnsurePurchasable(
-            db, account, request.ShopUniqueId, shopExcel, request.PurchaseCount);
+            db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
-        var consumeParcels = new List<ParcelInfo>();
-        for (int i = 0; i < (goodsExcel.ConsumeParcelType ?? []).Count; i++)
-        {
-            consumeParcels.Add(new ParcelInfo
-            {
-                Key = new ParcelKeyPair { Type = goodsExcel.ConsumeParcelType[i], Id = goodsExcel.ConsumeParcelId[i] },
-                Amount = goodsExcel.ConsumeParcelAmount[i] * request.PurchaseCount
-            });
-        }
-
-        var rewardParcels = new List<ParcelInfo>();
-        for (int i = 0; i < (goodsExcel.ParcelType ?? []).Count; i++)
-        {
-            rewardParcels.Add(new ParcelInfo
-            {
-                Key = new ParcelKeyPair { Type = goodsExcel.ParcelType[i], Id = goodsExcel.ParcelId[i] },
-                Amount = goodsExcel.ParcelAmount[i] * request.PurchaseCount
-            });
-        }
+        var consumeParcels = BuildParcels(
+            goodsExcel.ConsumeParcelType, goodsExcel.ConsumeParcelId, goodsExcel.ConsumeParcelAmount, purchaseCount);
+        var rewardParcels = BuildParcels(
+            goodsExcel.ParcelType, goodsExcel.ParcelId, goodsExcel.ParcelAmount, purchaseCount);
 
         var consumeResolver = await _parcelHandler.BuildParcel(db, account, consumeParcels, isConsume: true);
 
@@ -686,7 +683,7 @@ public class ShopHandler : ProtocolHandlerBase
         parcelResultDB.AcquiredItems = rewardParcels;
         response.ParcelResultDB = parcelResultDB;
 
-        purchaseHistory.PurchaseCount += request.PurchaseCount;
+        purchaseHistory.PurchaseCount += purchaseCount;
 
         response.ShopProductDB = new ShopProductDB
         {
@@ -722,7 +719,7 @@ public class ShopHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
-        ValidatePurchaseCount(request.PurchaseCount);
+        var purchaseCount = NormalizePurchaseCount(request.PurchaseCount);
 
         // Failures are Error packets, never empty successes - official rejects with a bare {Protocol:-1, ErrorCode, ServerTimeTicks} envelope (captured on the AP-cap rejection).
         var shopExcel = _excelService.GetTable<ShopExcelT>().FirstOrDefault(x => x.Id == request.ShopUniqueId);
@@ -741,7 +738,7 @@ public class ShopHandler : ProtocolHandlerBase
             : (long)CurrencyTypes.Gem;
         var costAmount = (goodsExcel.ConsumeParcelAmount != null && goodsExcel.ConsumeParcelAmount.Count > 0 
             ? goodsExcel.ConsumeParcelAmount[0] 
-            : 0) * request.PurchaseCount;
+            : 0) * purchaseCount;
 
         var costCurrency = costParcelType == ParcelType.Currency ? (CurrencyTypes)costParcelId : CurrencyTypes.Gem;
         
@@ -761,11 +758,11 @@ public class ShopHandler : ProtocolHandlerBase
             && rewardParcelId == (long)CurrencyTypes.ActionPoint
             && rewardPerCount is > 0 and <= 999
                 ? rewardPerCount
-                : 120) * request.PurchaseCount;
+                : 120) * purchaseCount;
         
         // The AP shop is capped at 20 purchases per game day (PurchaseCountLimit in the excel, confirmed on the wire); tracked per reset window so the counter rolls over at 04:00.
         var purchaseHistory = await ShopManager.EnsurePurchasable(
-            db, account, request.ShopUniqueId, shopExcel, request.PurchaseCount);
+            db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
         var accountCurrency = db.GetAccountCurrencies(account.ServerId).FirstOrDefault();
         if (accountCurrency == null)
@@ -793,7 +790,7 @@ public class ShopHandler : ProtocolHandlerBase
         accountCurrency.CurrencyDict[rewardCurrency] += rewardAmount;
         accountCurrency.UpdateTimeDict[rewardCurrency] = account.GameSettings.ServerDateTime();
 
-        purchaseHistory.PurchaseCount += request.PurchaseCount;
+        purchaseHistory.PurchaseCount += purchaseCount;
 
         await db.SaveChangesAsync();
 
@@ -829,9 +826,13 @@ public class ShopHandler : ProtocolHandlerBase
         };
 
         var buyApMissions = _missionService.UpdateMissionProgress(
-            db, account, MissionCompleteConditionType.Reset_ShopBuyActionPointCount, request.PurchaseCount);
+            db, account, MissionCompleteConditionType.Reset_ShopBuyActionPointCount, purchaseCount);
         if (buyApMissions.Count > 0)
             response.MissionProgressDBs = buyApMissions;
+
+        // UpdateMissionProgress only stages the rows; the SaveChanges above already ran, so without this the
+        // client is told the mission moved and the next Mission_List says it never did.
+        await db.SaveChangesAsync();
 
         return response;
     }

--- a/Shittim-Server/GameMasters/CharacterGM.cs
+++ b/Shittim-Server/GameMasters/CharacterGM.cs
@@ -548,13 +548,14 @@ namespace Shittim.GameMasters
                         await connection.SendChatMessage("Invalid level parameter!");
                     break;
                 case "star":
-                    if (int.TryParse(parameters, out int star))
+                    // Bounded: the client draws five slots and a grade outside them is a value it cannot render.
+                    if (int.TryParse(parameters, out int star) && star is >= 1 and <= 5)
                     {
                         character.StarGrade = star;
                         await connection.SendChatMessage($"Character {characterId} star grade set to {star}");
                     }
                     else
-                        await connection.SendChatMessage("Invalid star parameter!");
+                        await connection.SendChatMessage("Invalid star parameter! Expected 1-5.");
                     break;
                 case "skill":
                     var skillLevels = parameters.Split(' ');

--- a/Shittim-Server/GameMasters/CharacterGM.cs
+++ b/Shittim-Server/GameMasters/CharacterGM.cs
@@ -602,46 +602,54 @@ namespace Shittim.GameMasters
             switch (option.ToLower())
             {
                 case "level":
-                    if (int.TryParse(parameters, out int level))
+                    if (!int.TryParse(parameters, out int level))
                     {
-                        foreach (var character in allCharacters)
-                            character.Level = level;
+                        await connection.SendChatMessage("Invalid level parameter!");
+                        return;
                     }
+                    foreach (var character in allCharacters)
+                        character.Level = level;
                     break;
                 case "star":
                     // Same bound as the single-character path: the client draws five slots.
-                    if (int.TryParse(parameters, out int star) && star is >= 1 and <= 5)
+                    if (!int.TryParse(parameters, out int star) || star is < 1 or > 5)
                     {
-                        foreach (var character in allCharacters)
-                            character.StarGrade = star;
+                        await connection.SendChatMessage("Invalid star parameter! Expected 1-5.");
+                        return;
                     }
+                    foreach (var character in allCharacters)
+                        character.StarGrade = star;
                     break;
                 case "skill":
                     var skillLevels = parameters.Split(' ');
-                    if (skillLevels.Length == 4 && skillLevels.All(x => int.TryParse(x, out _)))
+                    if (skillLevels.Length != 4 || !skillLevels.All(x => int.TryParse(x, out _)))
                     {
-                        foreach (var character in allCharacters)
-                        {
-                            character.ExSkillLevel = int.Parse(skillLevels[0]);
-                            character.PublicSkillLevel = int.Parse(skillLevels[1]);
-                            character.PassiveSkillLevel = int.Parse(skillLevels[2]);
-                            character.ExtraPassiveSkillLevel = int.Parse(skillLevels[3]);
-                        }
+                        await connection.SendChatMessage("Invalid skill levels! Format: {skill1 skill2 skill3 skill4}");
+                        return;
+                    }
+                    foreach (var character in allCharacters)
+                    {
+                        character.ExSkillLevel = int.Parse(skillLevels[0]);
+                        character.PublicSkillLevel = int.Parse(skillLevels[1]);
+                        character.PassiveSkillLevel = int.Parse(skillLevels[2]);
+                        character.ExtraPassiveSkillLevel = int.Parse(skillLevels[3]);
                     }
                     break;
                 case "ps":
                     var potentialStats = parameters.Split(' ');
-                    if (potentialStats.Length == 3 && potentialStats.All(x => int.TryParse(x, out _)))
+                    if (potentialStats.Length != 3 || !potentialStats.All(x => int.TryParse(x, out _)))
                     {
-                        foreach (var character in allCharacters)
+                        await connection.SendChatMessage("Invalid potential stats! Format: {ps1 ps2 ps3}");
+                        return;
+                    }
+                    foreach (var character in allCharacters)
+                    {
+                        character.PotentialStats = new Dictionary<int, int>
                         {
-                            character.PotentialStats = new Dictionary<int, int>
-                            {
-                                { 1, int.Parse(potentialStats[0]) },
-                                { 2, int.Parse(potentialStats[1]) },
-                                { 3, int.Parse(potentialStats[2]) }
-                            };
-                        }
+                            { 1, int.Parse(potentialStats[0]) },
+                            { 2, int.Parse(potentialStats[1]) },
+                            { 3, int.Parse(potentialStats[2]) }
+                        };
                     }
                     break;
                 default:

--- a/Shittim-Server/GameMasters/CharacterGM.cs
+++ b/Shittim-Server/GameMasters/CharacterGM.cs
@@ -609,7 +609,8 @@ namespace Shittim.GameMasters
                     }
                     break;
                 case "star":
-                    if (int.TryParse(parameters, out int star))
+                    // Same bound as the single-character path: the client draws five slots.
+                    if (int.TryParse(parameters, out int star) && star is >= 1 and <= 5)
                     {
                         foreach (var character in allCharacters)
                             character.StarGrade = star;

--- a/Shittim-Server/Services/ConsumeHandler.cs
+++ b/Shittim-Server/Services/ConsumeHandler.cs
@@ -112,7 +112,9 @@ public class ConsumeResolver
 
     public void HandleEquipmentConsumption(ConsumeRequestDB consumeRequest)
     {
-        foreach (var consumeData in consumeRequest.ConsumeEquipmentServerIdAndCounts)
+        // The model declares this nullable and the client omits the kinds it is not consuming; iterating it raw
+        // turned every such request into a 500.
+        foreach (var consumeData in consumeRequest.ConsumeEquipmentServerIdAndCounts ?? [])
         {
             var equipment = Context.Equipments.FirstOrDefault(x => x.AccountServerId == Account.ServerId && x.ServerId == consumeData.Key);
             if (equipment == null) continue;
@@ -144,7 +146,9 @@ public class ConsumeResolver
 
     public void HandleFurnitureConsumption(ConsumeRequestDB consumeRequest)
     {
-        foreach (var consumeData in consumeRequest.ConsumeFurnitureServerIdAndCounts)
+        // The model declares this nullable and the client omits the kinds it is not consuming; iterating it raw
+        // turned every such request into a 500.
+        foreach (var consumeData in consumeRequest.ConsumeFurnitureServerIdAndCounts ?? [])
         {
             var furniture = Context.Furnitures.FirstOrDefault(x => x.AccountServerId == Account.ServerId && x.ServerId == consumeData.Key);
             if (furniture == null) continue;
@@ -176,7 +180,9 @@ public class ConsumeResolver
 
     public void HandleItemConsumption(ConsumeRequestDB consumeRequest)
     {
-        foreach (var consumeData in consumeRequest.ConsumeItemServerIdAndCounts)
+        // The model declares this nullable and the client omits the kinds it is not consuming; iterating it raw
+        // turned every such request into a 500.
+        foreach (var consumeData in consumeRequest.ConsumeItemServerIdAndCounts ?? [])
         {
             var item = Context.Items.FirstOrDefault(x => x.AccountServerId == Account.ServerId && x.ServerId == consumeData.Key);
             if (item == null) continue;

--- a/Shittim-Server/Services/MomoTalkService.cs
+++ b/Shittim-Server/Services/MomoTalkService.cs
@@ -1,4 +1,6 @@
+using Schale.Data;
 using Schale.Data.GameModel;
+using Schale.FlatData;
 
 namespace BlueArchiveAPI.Services
 {
@@ -12,6 +14,111 @@ namespace BlueArchiveAPI.Services
                 favorSchedules[outline.CharacterId] = outline.ScheduleIds;
             }
             return favorSchedules;
+        }
+
+        /// <summary>
+        /// The group a student's MomoTalk opens on, or 0 while their first conversation is still rank-locked.
+        /// AcademyMessangerExcel numbers a student's groups in reading order and only the opening one has nothing
+        /// pointing at it, so the lowest id is the entry point; it carries the FavorRankUp condition that unlocks it
+        /// (true for 255 of the 256 students in the live table).
+        /// </summary>
+        public static long OpeningGroup(
+            List<AcademyMessangerExcelT> messengers, long characterId, long favorRank)
+        {
+            var opening = messengers
+                .Where(x => x.CharacterId == characterId)
+                .GroupBy(x => x.MessageGroupId)
+                .OrderBy(g => g.Key)
+                .FirstOrDefault();
+
+            if (opening == null || !IsUnlocked(opening, favorRank))
+                return 0;
+
+            return opening.Key;
+        }
+
+        /// <summary>
+        /// The group after <paramref name="currentGroupId"/> when it is a conversation that a rank-up has just
+        /// opened, otherwise 0. Ordinary continuations are excluded on purpose: the client walks those itself
+        /// through MomoTalk_Read, and pushing them here would spill a conversation the player has not read yet.
+        /// </summary>
+        public static long RankUnlockedGroup(
+            List<AcademyMessangerExcelT> messengers, long currentGroupId, long favorRank)
+        {
+            var nextGroupId = messengers
+                .Where(x => x.MessageGroupId == currentGroupId && x.NextGroupId > 0 && x.NextGroupId != currentGroupId)
+                .Select(x => x.NextGroupId)
+                .FirstOrDefault();
+
+            if (nextGroupId == 0)
+                return 0;
+
+            var next = messengers.Where(x => x.MessageGroupId == nextGroupId).ToList();
+            if (next.Count == 0)
+                return 0;
+
+            var opening = next.OrderBy(x => x.Id).First();
+            if (opening.MessageCondition != AcademyMessageConditions.FavorRankUp
+                || favorRank < opening.ConditionValue)
+            {
+                return 0;
+            }
+
+            return nextGroupId;
+        }
+
+        /// <summary>
+        /// Gives every owned student the outline row the MomoTalk list renders from, and moves a student whose
+        /// conversation stopped at a FavorRankUp gate onto the conversation that rank has since opened. Without this
+        /// a fresh account has no rows at all, so no conversation can be started, and a conversation that ran into a
+        /// gate never resumes - the client has no reason to send another MomoTalk_Read for a group it already read.
+        /// The rows are added to the context but not saved - the caller's SaveChangesAsync commits them.
+        /// </summary>
+        public static void SyncOutlines(
+            SchaleDataContext context, AccountDBServer account, List<AcademyMessangerExcelT> messengers)
+        {
+            var outlinesByCharacterDbId = context.GetAccountMomoTalkOutLines(account.ServerId)
+                .ToList()
+                .ToDictionary(x => x.CharacterDBId);
+
+            var now = account.GameSettings.ServerDateTime();
+
+            foreach (var character in context.Characters
+                         .Where(x => x.AccountServerId == account.ServerId).ToList())
+            {
+                if (outlinesByCharacterDbId.TryGetValue(character.ServerId, out var outline))
+                {
+                    var unlocked = RankUnlockedGroup(
+                        messengers, outline.LatestMessageGroupId, character.FavorRank);
+                    if (unlocked == 0)
+                        continue;
+
+                    outline.LatestMessageGroupId = unlocked;
+                    outline.ChosenMessageId = null;
+                    outline.LastUpdateDate = now;
+                    continue;
+                }
+
+                var opening = OpeningGroup(messengers, character.UniqueId, character.FavorRank);
+                if (opening == 0)
+                    continue;
+
+                context.MomoTalkOutLines.Add(new MomoTalkOutLineDBServer
+                {
+                    AccountServerId = account.ServerId,
+                    CharacterDBId = character.ServerId,
+                    CharacterId = character.UniqueId,
+                    LatestMessageGroupId = opening,
+                    LastUpdateDate = now
+                });
+            }
+        }
+
+        private static bool IsUnlocked(IEnumerable<AcademyMessangerExcelT> group, long favorRank)
+        {
+            var opening = group.OrderBy(x => x.Id).First();
+            return opening.MessageCondition != AcademyMessageConditions.FavorRankUp
+                || favorRank >= opening.ConditionValue;
         }
     }
 }

--- a/Shittim-Server/Services/MomoTalkService.cs
+++ b/Shittim-Server/Services/MomoTalkService.cs
@@ -77,9 +77,12 @@ namespace BlueArchiveAPI.Services
         public static void SyncOutlines(
             SchaleDataContext context, AccountDBServer account, List<AcademyMessangerExcelT> messengers)
         {
+            // Grouped rather than keyed directly: a duplicate row from older data would throw out of ToDictionary,
+            // and this runs on the login path where that would cost the account its session rather than a conversation.
             var outlinesByCharacterDbId = context.GetAccountMomoTalkOutLines(account.ServerId)
                 .ToList()
-                .ToDictionary(x => x.CharacterDBId);
+                .GroupBy(x => x.CharacterDBId)
+                .ToDictionary(g => g.Key, g => g.First());
 
             var now = account.GameSettings.ServerDateTime();
 

--- a/Shittim-Server/Services/MomoTalkService.cs
+++ b/Shittim-Server/Services/MomoTalkService.cs
@@ -68,6 +68,42 @@ namespace BlueArchiveAPI.Services
         }
 
         /// <summary>
+        /// Where an existing outline should resume, or 0 to leave it. A pending gate recorded by MomoTalk_Read is
+        /// authoritative: it opens once the rank is reached. Rows without one predate the marker, and there
+        /// LatestMessageGroupId cannot distinguish "read and stopped at the next group's gate" from "next unread
+        /// group" - advancing an unread group skips its story - so those only move when a recorded choice proves
+        /// the current group was read.
+        /// </summary>
+        public static long ResumeGroup(
+            List<AcademyMessangerExcelT> messengers,
+            long currentGroupId,
+            long? pendingGateGroupId,
+            bool currentGroupWasRead,
+            long favorRank)
+        {
+            if (pendingGateGroupId is > 0)
+            {
+                var opening = messengers
+                    .Where(x => x.MessageGroupId == pendingGateGroupId)
+                    .OrderBy(x => x.Id)
+                    .FirstOrDefault();
+                if (opening == null)
+                    return 0;
+                if (opening.MessageCondition == AcademyMessageConditions.FavorRankUp
+                    && favorRank < opening.ConditionValue)
+                {
+                    return 0;
+                }
+                return pendingGateGroupId.Value;
+            }
+
+            if (!currentGroupWasRead)
+                return 0;
+
+            return RankUnlockedGroup(messengers, currentGroupId, favorRank);
+        }
+
+        /// <summary>
         /// Gives every owned student the outline row the MomoTalk list renders from, and moves a student whose
         /// conversation stopped at a FavorRankUp gate onto the conversation that rank has since opened. Without this
         /// a fresh account has no rows at all, so no conversation can be started, and a conversation that ran into a
@@ -86,17 +122,28 @@ namespace BlueArchiveAPI.Services
 
             var now = account.GameSettings.ServerDateTime();
 
+            var readGroups = context.GetAccountMomoTalkChoices(account.ServerId)
+                .Select(c => new { c.CharacterDBId, c.MessageGroupId })
+                .ToList()
+                .Select(c => (c.CharacterDBId, c.MessageGroupId))
+                .ToHashSet();
+
             foreach (var character in context.Characters
                          .Where(x => x.AccountServerId == account.ServerId).ToList())
             {
                 if (outlinesByCharacterDbId.TryGetValue(character.ServerId, out var outline))
                 {
-                    var unlocked = RankUnlockedGroup(
-                        messengers, outline.LatestMessageGroupId, character.FavorRank);
-                    if (unlocked == 0)
+                    var resume = ResumeGroup(
+                        messengers,
+                        outline.LatestMessageGroupId,
+                        outline.PendingGateGroupId,
+                        readGroups.Contains((outline.CharacterDBId, outline.LatestMessageGroupId)),
+                        character.FavorRank);
+                    if (resume == 0)
                         continue;
 
-                    outline.LatestMessageGroupId = unlocked;
+                    outline.LatestMessageGroupId = resume;
+                    outline.PendingGateGroupId = null;
                     outline.ChosenMessageId = null;
                     outline.LastUpdateDate = now;
                     continue;

--- a/ShittimControlCenter/src/js/pages/overview.js
+++ b/ShittimControlCenter/src/js/pages/overview.js
@@ -46,7 +46,7 @@ export default {
     const offlineCard = cardWith('Offline mode', 'No route out, no name server', [],
       el('div', {},
         el('div.row.wrap', { style: { gap: '10px', minWidth: '0' } }, offlineBtn, hostsBtn),
-        el('p', { text: 'Brings the server and the proxy up with their offline switches on and points every host the client contacts at loopback, so nothing it asks for needs a name server or a route out. Steam still has to be running - offline mode is fine, but the client reads the SDK version back before it will boot at all.', style: { fontSize: '12.5px', color: 'var(--ink-3)', margin: '12px 0 0', lineHeight: '1.6' } }),
+        el('p', { text: 'Brings the server and the proxy up with their offline switches on and points every host the client contacts at loopback, so nothing it asks for needs a name server or a route out. Steam still has to be running - its own Offline Mode is fine, but the client reads the SDK version back before it will boot at all. Leave the network adapter up: the offline patch bypasses the Steam calls made after the SDK starts, not the SDK start itself, so pulling the cable or switching wifi off fails at boot with "Failed to connect to the network" no matter what the patch log says.', style: { fontSize: '12.5px', color: 'var(--ink-3)', margin: '12px 0 0', lineHeight: '1.6' } }),
         hostsLine));
 
     const exportBtn = button('Export logs', { variant: 'ghost', iconName: 'save', onClick: async () => {


### PR DESCRIPTION
## Summary

- **MomoTalk**: conversations now open for every owned student. Outlines are synced from `AcademyMessangerExcel` during login sync (the client caches that list per session), and the conversation walk follows the shipped Excel chain correctly.
- **Shop**: single-unit buys no longer lose the purchase. Clients send `PurchaseCount = 0` for one-unit buys; `NormalizePurchaseCount` charges one unit instead of zero, and bounds the count two-sided so a negative count cannot invert a cost into a grant.
- **Scenario**: `Scenario_Enter` is now answered. Unregistered, the gateway replied `ServerFailedToHandleRequest` and final-story episodes dropped the client to the title screen.
- **GM**: star grade is bounded to 1-5 on both the single `character modify ... star` path and the modify-all path; the client cannot render grades outside its five slots.
- **Consume**: a partly-filled `ConsumeRequestDB` no longer 500s the request.
- **Event reward paths**: all goods loops (event shop, box gacha, card shop, fortune gacha, refresh shop) index their parcel columns to the shortest of Type/Id/Amount, so a ragged Excel row can no longer throw `IndexOutOfRange` mid-purchase.

## Test evidence

`dotnet test Shittim-Server.Tests` on top of current `main` (481fbe3):

```
Passed!  - Failed: 0, Passed: 309, Skipped: 0, Total: 309, Duration: 22 s
```

New tests included: MomoTalk conversation chain + shipped-Excel walk, protocol registration guards, and shop purchase-count limits.