### PR TITLE
feature(protocol): implement every remaining unhandled protocol (216) and the subsystems they need

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -116,3 +116,4 @@ ida_pro_metadata/il2cpp.h
 # *.key, *.crt and other rules above (Git uses last-match-wins).
 !/Shittim-Server/config/
 !/Shittim-Server/config/**
+.claude/

--- a/Schale/Data/GameModel/GameContentModel/RaidDB.cs
+++ b/Schale/Data/GameModel/GameContentModel/RaidDB.cs
@@ -36,6 +36,7 @@ namespace Schale.Data.GameModel
         public long SessionHitPoint { get; set; }
         public long AccountLevelWhenCreateDB { get; set; }
         public bool ClanAssistUsed { get; set; }
+        public bool IsRewardReceived { get; set; }
     }
 
     public static class RaidDBServerExtensions

--- a/Schale/Data/GameModel/ProgressModel/ConquestInfoDB.cs
+++ b/Schale/Data/GameModel/ProgressModel/ConquestInfoDB.cs
@@ -1,0 +1,58 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+using Schale.FlatData;
+using Schale.MX.GameLogic.DBModel;
+
+namespace Schale.Data.GameModel
+{
+    // One row per (account, conquest event). The JSON columns hold wire-shaped types, so responses serve
+    // them without a mapping step.
+    public class ConquestInfoDBServer
+    {
+        [JsonIgnore]
+        public virtual AccountDBServer? Account { get; set; }
+
+        [Key]
+        [JsonIgnore]
+        public long ServerId { get; set; }
+
+        [JsonIgnore]
+        public long AccountServerId { get; set; }
+
+        public long EventContentId { get; set; }
+        public int EventGauge { get; set; }
+        public int EventSpawnCount { get; set; }
+        public int EchelonChangeCount { get; set; }
+        public int TodayConquestRentCount { get; set; }
+        public int TodayOperationRentCount { get; set; }
+        public long CumulatedConditionValue { get; set; }
+        public long ReceivedCalculateRewardConditionAmount { get; set; }
+        public bool FirstEnterDone { get; set; }
+
+        public Dictionary<StageDifficulty, int> StepByDifficulty { get; set; } = [];
+        public List<ConquestTileDB> Tiles { get; set; } = [];
+        public List<ConquestEchelonDB> Echelons { get; set; } = [];
+        public ConquestStageSaveDB? OpenBattle { get; set; }
+
+        public ConquestInfoDB ToInfoDB(long calculateConditionAmount) => new()
+        {
+            EventContentId = EventContentId,
+            EventGauge = EventGauge,
+            EventSpawnCount = EventSpawnCount,
+            EchelonChangeCount = EchelonChangeCount,
+            TodayConquestRentCount = TodayConquestRentCount,
+            TodayOperationRentCount = TodayOperationRentCount,
+            CumulatedConditionValue = CumulatedConditionValue,
+            ReceivedCalculateRewardConditionAmount = ReceivedCalculateRewardConditionAmount,
+            CalculateRewardConditionValue = calculateConditionAmount
+        };
+    }
+
+    public static class ConquestInfoDBServerExtensions
+    {
+        public static IQueryable<ConquestInfoDBServer> GetAccountConquestInfos(this SchaleDataContext context, long accountId)
+        {
+            return context.ConquestInfos.Where(x => x.AccountServerId == accountId);
+        }
+    }
+}

--- a/Schale/Data/GameModel/ProgressModel/MomoTalkOutLineDB.cs
+++ b/Schale/Data/GameModel/ProgressModel/MomoTalkOutLineDB.cs
@@ -18,6 +18,13 @@ namespace Schale.Data.GameModel
         public long CharacterDBId { get; set; }
         public long CharacterId { get; set; }
         public long LatestMessageGroupId { get; set; }
+
+        // Set when a MomoTalk_Read stopped because the next group opens with a FavorRankUp gate the student has
+        // not reached. LatestMessageGroupId alone cannot distinguish that state from "next unread group", and
+        // the login sync must not advance an unread group - that would skip its story.
+        [JsonIgnore]
+        public long? PendingGateGroupId { get; set; }
+
         public long? ChosenMessageId { get; set; }
         public List<long> ScheduleIds { get; set; } = [];
         public DateTime LastUpdateDate { get; set; }

--- a/Schale/Data/GameModel/ProgressModel/ShiftingCraftInfoDBServer.cs
+++ b/Schale/Data/GameModel/ProgressModel/ShiftingCraftInfoDBServer.cs
@@ -1,0 +1,24 @@
+using System.ComponentModel.DataAnnotations;
+using System.Text.Json.Serialization;
+
+namespace Schale.Data.GameModel
+{
+    public class ShiftingCraftInfoDBServer
+    {
+        [JsonIgnore]
+        public virtual AccountDBServer? Account { get; set; }
+
+        [JsonIgnore]
+        public long AccountServerId { get; set; }
+
+        [Key]
+        [JsonIgnore]
+        public long ServerId { get; set; }
+
+        public long SlotSequence { get; set; }
+        public long CraftRecipeId { get; set; }
+        public long CraftAmount { get; set; }
+        public DateTime StartTime { get; set; }
+        public DateTime EndTime { get; set; }
+    }
+}

--- a/Schale/Data/GameModel/ServerModel/AccountGameSettingDB.cs
+++ b/Schale/Data/GameModel/ServerModel/AccountGameSettingDB.cs
@@ -1,7 +1,20 @@
+using Schale.FlatData;
 using Schale.MX.GameLogic.DBModel;
 
 namespace Schale.Data.GameModel
 {
+    // The account's membership in the single emulated clan. HasClan defaults true so existing accounts
+    // deserialize as already inside the stock Arona clan, which is what the shipped Clan_Lobby always showed.
+    public class ClanStateDB
+    {
+        public bool HasClan { get; set; } = true;
+        public bool IsPlayerOwned { get; set; }
+        public string? ClanName { get; set; }
+        public string? Notice { get; set; }
+        public ClanJoinOption JoinOption { get; set; } = ClanJoinOption.Free;
+        public DateTime JoinDate { get; set; }
+    }
+
     public class AccountGameSettingDB
     {
         public bool BypassTeamDeployment { get; set; } = false;
@@ -10,6 +23,15 @@ namespace Schale.Data.GameModel
         public bool ForceDateTime { get; set; } = false;
         public bool BypassCafeSummon { get; set; } = false;
         public List<MultiSweepPresetDB> MultiSweepPresetDBs { get; set; } = [];
+        public bool CheckAdultAgree { get; set; }
+        public SkipHistoryDB? SkipHistory { get; set; }
+        public List<OpenConditionDB> OpenConditions { get; set; } = [];
+        public List<ResetableContentValueDB> ResetableContents { get; set; } = [];
+        public int LastBirthdayMailYear { get; set; }
+        public List<long> BlockedAccountIds { get; set; } = [];
+        public FriendIdCardDB? FriendIdCard { get; set; }
+        public Dictionary<long, long> PendingPurchaseOrders { get; set; } = [];
+        public ClanStateDB Clan { get; set; } = new();
         public DateTimeOffset ForceDateTimeOffset { get; set; } = DateTimeOffset.Now;
         public DateTimeOffset CurrentDateTime { get; set; } = DateTimeOffset.Now;
 

--- a/Schale/Data/GameModel/UserModel/AccountDB.cs
+++ b/Schale/Data/GameModel/UserModel/AccountDB.cs
@@ -44,6 +44,7 @@ namespace Schale.Data.GameModel
         internal virtual ICollection<StickerBookDBServer> StickerBooks { get; }
         internal virtual ICollection<ShopFreeRecruitHistoryDBServer> ShopFreeRecruitHistories { get; }
         internal virtual ICollection<CraftInfoDBServer> CraftInfos { get; }
+        internal virtual ICollection<ShiftingCraftInfoDBServer> ShiftingCraftInfos { get; }
 
         internal virtual ICollection<SingleRaidLobbyInfoDBServer> SingleRaidLobbyInfos { get; }
         internal virtual ICollection<EliminateRaidLobbyInfoDBServer> EliminateRaidLobbyInfos { get; }
@@ -102,6 +103,7 @@ namespace Schale.Data.GameModel
             StickerBooks = new List<StickerBookDBServer>();
             ShopFreeRecruitHistories = new List<ShopFreeRecruitHistoryDBServer>();
             CraftInfos = new List<CraftInfoDBServer>();
+            ShiftingCraftInfos = new List<ShiftingCraftInfoDBServer>();
 
             SingleRaidLobbyInfos = new List<SingleRaidLobbyInfoDBServer>();
             EliminateRaidLobbyInfos = new List<EliminateRaidLobbyInfoDBServer>();

--- a/Schale/Data/GameModel/UserModel/EquipmentDB.cs
+++ b/Schale/Data/GameModel/UserModel/EquipmentDB.cs
@@ -18,6 +18,7 @@ namespace Schale.Data.GameModel
         public long Exp { get; set; } = 0;
         public int Tier { get; set; } = 1;
         public long BoundCharacterServerId { get; set; }
+        public bool IsLocked { get; set; }
 
         [JsonIgnore]
         public override bool CanConsume => false;

--- a/Schale/Data/GameModel/UserModel/ItemDB.cs
+++ b/Schale/Data/GameModel/UserModel/ItemDB.cs
@@ -17,6 +17,8 @@ namespace Schale.Data.GameModel
         [NotMapped]
         [JsonIgnore]
         public override bool CanConsume => true;
+
+        public bool IsLocked { get; set; }
     }
 
     public static class ItemDBServerExtensions

--- a/Schale/Data/SchaleDataContext.cs
+++ b/Schale/Data/SchaleDataContext.cs
@@ -55,6 +55,7 @@ namespace Schale.Data
         public DbSet<StickerBookDBServer> StickerBooks { get; set; }
         public DbSet<ShopFreeRecruitHistoryDBServer> ShopFreeRecruitHistories { get; set; }
         public DbSet<CraftInfoDBServer> CraftInfos { get; set; }
+        public DbSet<ShiftingCraftInfoDBServer> ShiftingCraftInfos { get; set; }
         public DbSet<MissionHistoryDBServer> MissionHistories { get; set; }
         public DbSet<BeforehandGachaHistoryDBServer> BeforehandGachaHistories { get; set; }
         public DbSet<ShopPurchaseHistoryDBServer> ShopPurchaseHistories { get; set; }
@@ -81,6 +82,7 @@ namespace Schale.Data
         public DbSet<WorldRaidLocalBossDBServer> WorldRaidLocalBosses { get; set; }
         public DbSet<WorldRaidBossListInfoDBServer> WorldRaidBossListInfos { get; set; }
         public DbSet<WorldRaidClearHistoryDBServer> WorldRaidClearHistories { get; set; }
+        public DbSet<ConquestInfoDBServer> ConquestInfos { get; set; }
 
         public DbSet<BattleSummaryDB> BattleSummaries { get; set; }
         public DbSet<RaidSummaryDB> RaidSummaries { get; set; }
@@ -159,6 +161,7 @@ namespace Schale.Data
             accountEntity.HasMany(x => x.StickerBooks).WithOne(x => x.Account).HasForeignKey(x => x.AccountServerId).IsRequired();
             accountEntity.HasMany(x => x.ShopFreeRecruitHistories).WithOne(x => x.Account).HasForeignKey(x => x.AccountServerId).IsRequired();
             accountEntity.HasMany(x => x.CraftInfos).WithOne(x => x.Account).HasForeignKey(x => x.AccountServerId).IsRequired();
+            accountEntity.HasMany(x => x.ShiftingCraftInfos).WithOne(x => x.Account).HasForeignKey(x => x.AccountServerId).IsRequired();
             
             accountEntity.HasMany(x => x.SingleRaidLobbyInfos).WithOne(x => x.Account).HasForeignKey(x => x.AccountServerId).IsRequired();
             accountEntity.HasMany(x => x.EliminateRaidLobbyInfos).WithOne(x => x.Account).HasForeignKey(x => x.AccountServerId).IsRequired();
@@ -276,6 +279,8 @@ namespace Schale.Data
             modelBuilder.Entity<CraftInfoDBServer>().Property(x => x.ResultIds).HasJsonConversion();
             modelBuilder.Entity<CraftInfoDBServer>().Property(x => x.RewardParcelInfos).HasJsonConversion();
 
+            modelBuilder.Entity<ShiftingCraftInfoDBServer>().Property(x => x.ServerId).ValueGeneratedOnAdd();
+
             modelBuilder.Entity<MissionHistoryDBServer>().Property(x => x.ServerId).ValueGeneratedOnAdd();
 
             modelBuilder.Entity<BeforehandGachaHistoryDBServer>().Property(x => x.ServerId).ValueGeneratedOnAdd();
@@ -373,6 +378,12 @@ namespace Schale.Data
             modelBuilder.Entity<WorldRaidBossListInfoDBServer>().Property(x => x.LocalBossDBs).HasJsonConversion();
 
             modelBuilder.Entity<WorldRaidClearHistoryDBServer>().Property(x => x.ServerId).ValueGeneratedOnAdd();
+
+            modelBuilder.Entity<ConquestInfoDBServer>().Property(x => x.ServerId).ValueGeneratedOnAdd();
+            modelBuilder.Entity<ConquestInfoDBServer>().Property(x => x.StepByDifficulty).HasJsonConversion();
+            modelBuilder.Entity<ConquestInfoDBServer>().Property(x => x.Tiles).HasJsonConversion();
+            modelBuilder.Entity<ConquestInfoDBServer>().Property(x => x.Echelons).HasJsonConversion();
+            modelBuilder.Entity<ConquestInfoDBServer>().Property(x => x.OpenBattle).HasJsonConversion();
         }
 
         private void ConfigureBattleModels(ModelBuilder modelBuilder)

--- a/Schale/MX/GameLogic/DBModel/DBModel.cs
+++ b/Schale/MX/GameLogic/DBModel/DBModel.cs
@@ -1102,6 +1102,7 @@ namespace Schale.MX.GameLogic.DBModel
         public long Exp { get; set; }
         public int Tier { get; set; }
         public long BoundCharacterServerId { get; set; }
+        public bool IsLocked { get; set; }
         public new bool CanConsume { get; set; }
     }
 
@@ -1388,6 +1389,7 @@ namespace Schale.MX.GameLogic.DBModel
 
         public override IEnumerable<ParcelInfo>? ParcelInfos { get; }
         public new bool CanConsume { get; set; }
+        public bool IsLocked { get; set; }
     }
 
     public class MailDB

--- a/Schale/MX/NetworkProtocol/NetworkProtocol.cs
+++ b/Schale/MX/NetworkProtocol/NetworkProtocol.cs
@@ -367,6 +367,8 @@ namespace Schale.MX.NetworkProtocol
         public string? EnterTicket { get; set; }
         public bool PassCookieResult { get; set; }
         public string? Cookie { get; set; }
+        public string? ClientGeneratedKey { get; set; }
+        public string? ClientGeneratedIV { get; set; }
     }
 
     public class AccountCheckYostarResponse : ResponsePacket
@@ -5062,6 +5064,11 @@ namespace Schale.MX.NetworkProtocol
     {
         public override Protocol Protocol { get => Protocol.MultiFloorRaid_Sync; }
         public List<MultiFloorRaidDB>? MultiFloorRaidDBs { get; set; }
+    }
+
+    public class MultiFloorRaidLoginRequest : RequestPacket
+    {
+        public override Protocol Protocol { get => Protocol.MultiFloorRaid_Login; }
     }
 
     // Official Account_LoginSync carries this child alongside MultiFloorRaidSyncResponse; on the wire it is just {"Protocol":49004} (all other members at defaults).

--- a/Schale/MappingProfiles/Mapping.cs
+++ b/Schale/MappingProfiles/Mapping.cs
@@ -97,6 +97,7 @@ namespace Schale.MappingProfiles
             CreateMap<AcademyLocationDBServer, AcademyLocationDB>();
             CreateMap<CampaignMainStageSaveDBServer, CampaignMainStageSaveDB>();
             CreateMap<CampaignMainStageSaveDBServer, EventContentMainStageSaveDB>();
+            CreateMap<CampaignMainStageSaveDBServer, StoryStrategyStageSaveDB>();
             CreateMap<CampaignChapterClearRewardHistoryDBServer, CampaignChapterClearRewardHistoryDB>();
             CreateMap<StrategyObjectHistoryDBServer, StrategyObjectHistoryDB>();
             CreateMap<ScenarioHistoryDBServer, ScenarioHistoryDB>();
@@ -109,6 +110,7 @@ namespace Schale.MappingProfiles
             CreateMap<EventContentPermanentDBServer, EventContentPermanentDB>();
             CreateMap<StickerBookDBServer, StickerBookDB>();
             CreateMap<CraftInfoDBServer, CraftInfoDB>();
+            CreateMap<ShiftingCraftInfoDBServer, ShiftingCraftInfoDB>();
         }
 
         private void ConfigureContentMappings()

--- a/Shittim-Server.Tests/ItemLockPersistenceTests.cs
+++ b/Shittim-Server.Tests/ItemLockPersistenceTests.cs
@@ -1,0 +1,48 @@
+using AutoMapper;
+using Microsoft.Extensions.DependencyInjection;
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+using Schale.Data.GameModel;
+using Schale.MappingProfiles;
+using Schale.MX.GameLogic.DBModel;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Controllers.Api;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+public class ItemLockPersistenceTests
+{
+    private static JObject Wire(ResponsePacket response) =>
+        JObject.Parse(JsonConvert.SerializeObject(response, GatewayController.OfficialPacketJsonSettings));
+
+    [Fact]
+    public void ALockedItemCarriesTheFlagThroughMapperAndWire()
+    {
+        var mapped = Mapper.Map<ItemDB>(new ItemDBServer { UniqueId = 2000, StackCount = 1, IsLocked = true });
+
+        var json = Wire(new ItemLockResponse { ItemDB = mapped });
+
+        Assert.True((bool)json["ItemDB"]!["IsLocked"]!);
+    }
+
+    [Fact]
+    public void ALockedEquipmentCarriesTheFlagThroughMapperAndWire()
+    {
+        var mapped = Mapper.Map<EquipmentDB>(new EquipmentDBServer { UniqueId = 1000, StackCount = 1, IsLocked = true });
+
+        var json = Wire(new EquipmentItemLockResponse { EquipmentDB = mapped });
+
+        Assert.True((bool)json["EquipmentDB"]!["IsLocked"]!);
+    }
+
+    private static readonly IMapper Mapper = BuildMapper();
+
+    private static IMapper BuildMapper()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAutoMapper(cfg => { }, typeof(GameModelsMappingProfile).Assembly);
+        return services.BuildServiceProvider().GetRequiredService<IMapper>();
+    }
+}

--- a/Shittim-Server.Tests/MomoTalkConversationChainTests.cs
+++ b/Shittim-Server.Tests/MomoTalkConversationChainTests.cs
@@ -53,6 +53,34 @@ public class MomoTalkConversationChainTests
         Assert.Equal(0, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040100, favorRank: 99));
     }
 
+    [Fact]
+    public void APendingGateOpensOnceTheRankIsThere()
+    {
+        // MomoTalk_Read stopped at 100040020 because 100040090 needs rank 3.
+        Assert.Equal(0, MomoTalkService.ResumeGroup(
+            Messengers, currentGroupId: 100040020, pendingGateGroupId: 100040090, currentGroupWasRead: true, favorRank: 2));
+        Assert.Equal(100040090, MomoTalkService.ResumeGroup(
+            Messengers, currentGroupId: 100040020, pendingGateGroupId: 100040090, currentGroupWasRead: true, favorRank: 3));
+    }
+
+    [Fact]
+    public void AnUnreadGroupIsNeverSkippedBySync()
+    {
+        // The outline points at 100040020 as the NEXT unread group (set by reading 100040011); the player already
+        // has rank 3, so 100040090's gate is open - but advancing would skip 100040020's unread messages.
+        Assert.Equal(0, MomoTalkService.ResumeGroup(
+            Messengers, currentGroupId: 100040020, pendingGateGroupId: null, currentGroupWasRead: false, favorRank: 3));
+    }
+
+    [Fact]
+    public void ALegacyRowResumesPastTheGateOnlyWithProofItWasRead()
+    {
+        // Rows written before the pending-gate marker existed: a recorded choice for the current group is the
+        // proof that it was read and the stop really was the gate.
+        Assert.Equal(100040090, MomoTalkService.ResumeGroup(
+            Messengers, currentGroupId: 100040020, pendingGateGroupId: null, currentGroupWasRead: true, favorRank: 3));
+    }
+
     private static AcademyMessangerExcelT Row(
         long id,
         long group,

--- a/Shittim-Server.Tests/MomoTalkConversationChainTests.cs
+++ b/Shittim-Server.Tests/MomoTalkConversationChainTests.cs
@@ -1,0 +1,70 @@
+using BlueArchiveAPI.Services;
+using Schale.FlatData;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+public class MomoTalkConversationChainTests
+{
+    // Shaped after the live AcademyMessangerExcel rows for character 10004: groups are numbered in reading order and
+    // chained end to end by NextGroupId, and a new conversation is marked by a FavorRankUp condition on the first
+    // row of the group it starts at (100040010 at rank 2, 100040090 at rank 3).
+    private static readonly List<AcademyMessangerExcelT> Messengers =
+    [
+        Row(id: 1, group: 100040010, next: 100040011, condition: AcademyMessageConditions.FavorRankUp, conditionValue: 2),
+        Row(id: 1, group: 100040011, next: 100040020),
+        Row(id: 1, group: 100040020, next: 100040090),
+        Row(id: 1, group: 100040090, next: 100040100, condition: AcademyMessageConditions.FavorRankUp, conditionValue: 3),
+        Row(id: 2, group: 100040090, next: 100040100),
+        Row(id: 1, group: 100040100, next: 0),
+    ];
+
+    [Fact]
+    public void AStudentOpensOnTheirLowestGroupOnceItsRankIsReached()
+    {
+        Assert.Equal(0, MomoTalkService.OpeningGroup(Messengers, characterId: 10004, favorRank: 1));
+        Assert.Equal(100040010, MomoTalkService.OpeningGroup(Messengers, characterId: 10004, favorRank: 2));
+    }
+
+    [Fact]
+    public void AnotherStudentGetsNothing()
+    {
+        Assert.Equal(0, MomoTalkService.OpeningGroup(Messengers, characterId: 20000, favorRank: 99));
+    }
+
+    [Fact]
+    public void AConversationStoppedAtARankGateResumesOnceTheRankIsThere()
+    {
+        Assert.Equal(0, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040020, favorRank: 2));
+        Assert.Equal(100040090, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040020, favorRank: 3));
+    }
+
+    [Fact]
+    public void AnOrdinaryContinuationIsLeftToTheClient()
+    {
+        // 100040011 follows 100040010 with no gate, so the player reads their way to it through MomoTalk_Read;
+        // pushing it here would spill messages they have not reached.
+        Assert.Equal(0, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040010, favorRank: 99));
+    }
+
+    [Fact]
+    public void TheLastGroupHasNothingAfterIt()
+    {
+        Assert.Equal(0, MomoTalkService.RankUnlockedGroup(Messengers, currentGroupId: 100040100, favorRank: 99));
+    }
+
+    private static AcademyMessangerExcelT Row(
+        long id,
+        long group,
+        long next,
+        AcademyMessageConditions condition = AcademyMessageConditions.None,
+        long conditionValue = 0) => new()
+        {
+            Id = id,
+            MessageGroupId = group,
+            CharacterId = 10004,
+            NextGroupId = next,
+            MessageCondition = condition,
+            ConditionValue = conditionValue
+        };
+}

--- a/Shittim-Server.Tests/MomoTalkShippedDataTests.cs
+++ b/Shittim-Server.Tests/MomoTalkShippedDataTests.cs
@@ -8,14 +8,25 @@ namespace Shittim_Server.Tests;
 // AcademyMessangerExcel, so the assumptions they encode - the opening group is the lowest id, its FavorRankUp
 // gate is on the first row, follow-up conversations hang off NextGroupId behind a rank gate - stay checked
 // against the shipped table rather than against my reading of it.
-// Skipped when no ExcelDB.db is available (CI, or a checkout without the client data).
+// Skipped when no ExcelDB.db is available (CI, or a checkout without the client data). The skip is decided by
+// the attribute so the runner reports these as skipped rather than green-while-asserting-nothing; a present but
+// unreadable database (rotated SQLCipher key) fails instead of passing silently.
 public class MomoTalkShippedDataTests
 {
-    [Fact]
+    private sealed class ShippedDataFactAttribute : FactAttribute
+    {
+        public ShippedDataFactAttribute()
+        {
+            var dumped = DumpedDir();
+            if (dumped == null || !File.Exists(Path.Combine(dumped, "ExcelDB.db")))
+                Skip = "Shipped ExcelDB.db not available in this checkout";
+        }
+    }
+
+    [ShippedDataFact]
     public void EveryStudentsConversationOpensAtTheLowestGroupBehindItsRankGate()
     {
         var messengers = ShippedMessengers();
-        if (messengers == null) return;
 
         var students = messengers.Where(x => x.CharacterId > 0).GroupBy(x => x.CharacterId).ToList();
         Assert.NotEmpty(students);
@@ -37,12 +48,11 @@ public class MomoTalkShippedDataTests
         }
     }
 
-    [Fact]
+    [ShippedDataFact]
     public void ARankGateIsAlwaysTheFirstRowOfTheGroupItGates()
     {
         // RankUnlockedGroup and the handler's own gate both read the condition off the group's opening row.
         var messengers = ShippedMessengers();
-        if (messengers == null) return;
 
         foreach (var group in messengers.GroupBy(x => x.MessageGroupId))
         {
@@ -52,11 +62,10 @@ public class MomoTalkShippedDataTests
         }
     }
 
-    [Fact]
+    [ShippedDataFact]
     public void AStudentsConversationsAreReachableOneRankGateAtATime()
     {
         var messengers = ShippedMessengers();
-        if (messengers == null) return;
 
         var student = messengers.Where(x => x.CharacterId > 0).GroupBy(x => x.CharacterId).OrderBy(x => x.Key).First();
 
@@ -92,26 +101,31 @@ public class MomoTalkShippedDataTests
         Assert.True(gatesCrossed > 0, "expected at least one rank-gated conversation on the sample student");
     }
 
-    private static List<AcademyMessangerExcelT>? ShippedMessengers()
+    private static string? DumpedDir()
     {
         var dir = AppContext.BaseDirectory;
         while (dir != null && !Directory.Exists(Path.Combine(dir, "Shittim-Server")))
             dir = Path.GetDirectoryName(dir);
 
-        var dumped = new[]
-        {
-            Path.Combine(dir!, "Shittim-Server", "Resources", "Dumped"),
-            Path.Combine(dir!, "Shittim-Server", "bin", "Debug", "net10.0", "Resources", "Dumped"),
-            Path.Combine(dir!, "Shittim-Server", "bin", "Release", "net10.0", "Resources", "Dumped"),
-        }.FirstOrDefault(Directory.Exists);
-
-        if (dumped == null)
+        if (dir == null)
             return null;
 
-        ExcelTableService.DumpedDir = dumped;
+        return new[]
+        {
+            Path.Combine(dir, "Shittim-Server", "Resources", "Dumped"),
+            Path.Combine(dir, "Shittim-Server", "bin", "Debug", "net10.0", "Resources", "Dumped"),
+            Path.Combine(dir, "Shittim-Server", "bin", "Release", "net10.0", "Resources", "Dumped"),
+        }.FirstOrDefault(Directory.Exists);
+    }
 
-        // Empty means the table degraded - no ExcelDB.db, or a SQLCipher key that has rotated.
+    private static List<AcademyMessangerExcelT> ShippedMessengers()
+    {
+        ExcelTableService.DumpedDir = DumpedDir()!;
+
+        // Empty means the table degraded - the SQLCipher key rotated or the dump is truncated. The attribute
+        // already skipped when the file is absent, so degradation here is a failure, not a skip.
         var messengers = new ExcelTableService().GetTable<AcademyMessangerExcelT>();
-        return messengers.Count > 0 ? messengers : null;
+        Assert.NotEmpty(messengers);
+        return messengers;
     }
 }

--- a/Shittim-Server.Tests/MomoTalkShippedDataTests.cs
+++ b/Shittim-Server.Tests/MomoTalkShippedDataTests.cs
@@ -1,0 +1,117 @@
+using BlueArchiveAPI.Services;
+using Schale.FlatData;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+// The chaining tests next door run on a hand-built fixture. These run the same two functions over the real
+// AcademyMessangerExcel, so the assumptions they encode - the opening group is the lowest id, its FavorRankUp
+// gate is on the first row, follow-up conversations hang off NextGroupId behind a rank gate - stay checked
+// against the shipped table rather than against my reading of it.
+// Skipped when no ExcelDB.db is available (CI, or a checkout without the client data).
+public class MomoTalkShippedDataTests
+{
+    [Fact]
+    public void EveryStudentsConversationOpensAtTheLowestGroupBehindItsRankGate()
+    {
+        var messengers = ShippedMessengers();
+        if (messengers == null) return;
+
+        var students = messengers.Where(x => x.CharacterId > 0).GroupBy(x => x.CharacterId).ToList();
+        Assert.NotEmpty(students);
+
+        foreach (var student in students)
+        {
+            var groups = student.GroupBy(x => x.MessageGroupId).ToDictionary(g => g.Key, g => g.OrderBy(x => x.Id).ToList());
+            var lowest = groups.Keys.Min();
+
+            // Nothing points at the opening group, so it is the one to seed an outline with.
+            var incoming = student.Where(x => x.NextGroupId > 0).Select(x => x.NextGroupId).ToHashSet();
+            Assert.Equal([lowest], groups.Keys.Where(k => !incoming.Contains(k)).OrderBy(k => k).ToList());
+
+            // Its gate decides whether the student has a conversation at all yet.
+            var gate = groups[lowest][0];
+            Assert.Equal(AcademyMessageConditions.FavorRankUp, gate.MessageCondition);
+            Assert.Equal(0, MomoTalkService.OpeningGroup(messengers, student.Key, gate.ConditionValue - 1));
+            Assert.Equal(lowest, MomoTalkService.OpeningGroup(messengers, student.Key, gate.ConditionValue));
+        }
+    }
+
+    [Fact]
+    public void ARankGateIsAlwaysTheFirstRowOfTheGroupItGates()
+    {
+        // RankUnlockedGroup and the handler's own gate both read the condition off the group's opening row.
+        var messengers = ShippedMessengers();
+        if (messengers == null) return;
+
+        foreach (var group in messengers.GroupBy(x => x.MessageGroupId))
+        {
+            var rows = group.OrderBy(x => x.Id).ToList();
+            if (rows.Any(x => x.MessageCondition == AcademyMessageConditions.FavorRankUp))
+                Assert.Equal(AcademyMessageConditions.FavorRankUp, rows[0].MessageCondition);
+        }
+    }
+
+    [Fact]
+    public void AStudentsConversationsAreReachableOneRankGateAtATime()
+    {
+        var messengers = ShippedMessengers();
+        if (messengers == null) return;
+
+        var student = messengers.Where(x => x.CharacterId > 0).GroupBy(x => x.CharacterId).OrderBy(x => x.Key).First();
+
+        var group = MomoTalkService.OpeningGroup(messengers, student.Key, 99);
+        Assert.NotEqual(0, group);
+
+        var gatesCrossed = 0;
+        for (var step = 0; step < 500; step++)
+        {
+            var next = messengers
+                .Where(x => x.MessageGroupId == group && x.NextGroupId > 0 && x.NextGroupId != group)
+                .Select(x => x.NextGroupId)
+                .FirstOrDefault();
+            if (next == 0) break;
+
+            // Every gate on the way is one the old code stopped at for good; RankUnlockedGroup has to find each.
+            var opening = messengers.Where(x => x.MessageGroupId == next).OrderBy(x => x.Id).First();
+            if (opening.MessageCondition == AcademyMessageConditions.FavorRankUp)
+            {
+                Assert.Equal(next, MomoTalkService.RankUnlockedGroup(messengers, group, 99));
+                Assert.Equal(0, MomoTalkService.RankUnlockedGroup(messengers, group, opening.ConditionValue - 1));
+                gatesCrossed++;
+            }
+            else
+            {
+                // An ordinary continuation is the client's job, never pushed from here.
+                Assert.Equal(0, MomoTalkService.RankUnlockedGroup(messengers, group, 99));
+            }
+
+            group = next;
+        }
+
+        Assert.True(gatesCrossed > 0, "expected at least one rank-gated conversation on the sample student");
+    }
+
+    private static List<AcademyMessangerExcelT>? ShippedMessengers()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !Directory.Exists(Path.Combine(dir, "Shittim-Server")))
+            dir = Path.GetDirectoryName(dir);
+
+        var dumped = new[]
+        {
+            Path.Combine(dir!, "Shittim-Server", "Resources", "Dumped"),
+            Path.Combine(dir!, "Shittim-Server", "bin", "Debug", "net10.0", "Resources", "Dumped"),
+            Path.Combine(dir!, "Shittim-Server", "bin", "Release", "net10.0", "Resources", "Dumped"),
+        }.FirstOrDefault(Directory.Exists);
+
+        if (dumped == null)
+            return null;
+
+        ExcelTableService.DumpedDir = dumped;
+
+        // Empty means the table degraded - no ExcelDB.db, or a SQLCipher key that has rotated.
+        var messengers = new ExcelTableService().GetTable<AcademyMessangerExcelT>();
+        return messengers.Count > 0 ? messengers : null;
+    }
+}

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -74,6 +74,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_Conquer)]
     [InlineData(Protocol.Conquest_ConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_ConquerWithBattleResult)]
+    [InlineData(Protocol.Conquest_ManageBase)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -83,6 +83,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_MapMove)]
     [InlineData(Protocol.Scenario_EndTurn)]
     [InlineData(Protocol.Scenario_EnterTactic)]
+    [InlineData(Protocol.Scenario_TacticResult)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -29,6 +29,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_VerifyCheckAdultAgree)]
     [InlineData(Protocol.Account_DismissRepurchasablePopup)]
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
+    [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
     [InlineData(Protocol.Account_CheckYostar)]
     [InlineData(Protocol.Account_PassCheck)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -31,6 +31,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
+    [InlineData(Protocol.Cafe_Travel)]
     [InlineData(Protocol.Audit_GachaStatistics)]
     [InlineData(Protocol.Account_CheckYostar)]
     [InlineData(Protocol.Account_PassCheck)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -36,6 +36,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
+    [InlineData(Protocol.MultiFloorRaid_Login)]
     [InlineData(Protocol.ContentSweep_MultiSweepPresetList)]
     [InlineData(Protocol.Item_Lock)]
     [InlineData(Protocol.Equipment_Lock)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -36,6 +36,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.ClearDeck_List)]
     [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]
+    [InlineData(Protocol.ContentSweep_SetMultiSweepPresetName)]
     [InlineData(Protocol.Character_FavorGrowth)]
     [InlineData(Protocol.Character_SetCostume)]
     [InlineData(Protocol.Cafe_Travel)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -28,6 +28,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_SetCheckAdultAgree)]
     [InlineData(Protocol.Account_VerifyCheckAdultAgree)]
     [InlineData(Protocol.Account_DismissRepurchasablePopup)]
+    [InlineData(Protocol.Account_ReportXignCodeCheater)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -93,6 +93,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
     [InlineData(Protocol.Craft_AutoBeginProcess)]
     [InlineData(Protocol.Craft_CompleteProcessAll)]
+    [InlineData(Protocol.Craft_RewardAll)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -76,6 +76,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Item_Sell)]
     [InlineData(Protocol.Equipment_Sell)]
     [InlineData(Protocol.Arena_EnterBattle)]
+    [InlineData(Protocol.Scenario_EnterMainStage)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -72,6 +72,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_GetInfo)]
     [InlineData(Protocol.Conquest_Check)]
     [InlineData(Protocol.Conquest_Conquer)]
+    [InlineData(Protocol.Conquest_ConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -92,6 +92,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
+    [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.Craft_AutoBeginProcess)]
     [InlineData(Protocol.Craft_CompleteProcessAll)]
     [InlineData(Protocol.Craft_RewardAll)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -47,6 +47,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
+    [InlineData(Protocol.Friend_Search)]
     [InlineData(Protocol.Friend_GetFriendDetailedInfo)]
     [InlineData(Protocol.Friend_SetIdCard)]
     [InlineData(Protocol.Billing_PurchaseListByYostar)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -58,6 +58,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_AutoJoin)]
     [InlineData(Protocol.Clan_Quit)]
     [InlineData(Protocol.Clan_Dismiss)]
+    [InlineData(Protocol.Clan_Search)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -91,6 +91,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquer)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
+    [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.Craft_AutoBeginProcess)]
     [InlineData(Protocol.Craft_CompleteProcessAll)]
     [InlineData(Protocol.Craft_RewardAll)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -1,0 +1,38 @@
+using System.Reflection;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+public class ProtocolRegistrationTests
+{
+    // An unregistered protocol is answered with ServerFailedToHandleRequest, which the client shows as
+    // "Server failed to process request. Returning to the title screen." These are the ones a normal session
+    // cannot get past, so a handler going missing should fail here rather than in someone's play session.
+    [Theory]
+    [InlineData(Protocol.Scenario_Enter)]
+    [InlineData(Protocol.Scenario_GroupHistoryUpdate)]
+    [InlineData(Protocol.Scenario_Clear)]
+    [InlineData(Protocol.MomoTalk_OutLine)]
+    [InlineData(Protocol.MomoTalk_Read)]
+    [InlineData(Protocol.MomoTalk_FavorSchedule)]
+    [InlineData(Protocol.Shop_BuyMerchandise)]
+    [InlineData(Protocol.Mission_Reward)]
+    [InlineData(Protocol.Mission_MultipleReward)]
+    [InlineData(Protocol.Craft_List)]
+    [InlineData(Protocol.Craft_SelectNode)]
+    public void TheProtocolHasAHandler(Protocol protocol)
+    {
+        Assert.Contains(protocol, HandledProtocols);
+    }
+
+    private static readonly HashSet<Protocol> HandledProtocols = typeof(ProtocolHandlerBase).Assembly
+        .GetTypes()
+        .Where(t => t.IsClass && !t.IsAbstract && t.IsAssignableTo(typeof(ProtocolHandlerBase)))
+        .SelectMany(t => t.GetMethods(BindingFlags.Public | BindingFlags.NonPublic | BindingFlags.Instance))
+        .SelectMany(m => m.GetCustomAttributes<ProtocolHandlerAttribute>())
+        .Select(a => a.Protocol)
+        .Where(p => p != Protocol.None)
+        .ToHashSet();
+}

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -91,6 +91,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquer)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
+    [InlineData(Protocol.Craft_AutoBeginProcess)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -76,6 +76,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_ConquerWithBattleResult)]
     [InlineData(Protocol.Conquest_ManageBase)]
     [InlineData(Protocol.Conquest_UpgradeBase)]
+    [InlineData(Protocol.Conquest_DeployEchelon)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -94,6 +94,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]
+    [InlineData(Protocol.EliminateRaid_LimitedReward)]
     [InlineData(Protocol.Craft_AutoBeginProcess)]
     [InlineData(Protocol.Craft_CompleteProcessAll)]
     [InlineData(Protocol.Craft_RewardAll)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -44,6 +44,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.BattlePass_MissionSingleReward)]
     [InlineData(Protocol.BattlePass_MissionMultipleReward)]
     [InlineData(Protocol.Arena_EnterBattle)]
+    [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -67,6 +67,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Kick)]
     [InlineData(Protocol.Clan_Confer)]
     [InlineData(Protocol.Clan_Setting)]
+    [InlineData(Protocol.Clan_ChatLog)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -85,6 +85,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_EnterTactic)]
     [InlineData(Protocol.Scenario_TacticResult)]
     [InlineData(Protocol.Scenario_Retreat)]
+    [InlineData(Protocol.Scenario_Portal)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -57,6 +57,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Join)]
     [InlineData(Protocol.Clan_AutoJoin)]
     [InlineData(Protocol.Clan_Quit)]
+    [InlineData(Protocol.Clan_Dismiss)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -56,6 +56,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Create)]
     [InlineData(Protocol.Clan_Join)]
     [InlineData(Protocol.Clan_AutoJoin)]
+    [InlineData(Protocol.Clan_Quit)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -52,6 +52,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Billing_TransactionEndByYostar)]
     [InlineData(Protocol.BattlePass_MissionSingleReward)]
     [InlineData(Protocol.BattlePass_MissionMultipleReward)]
+    [InlineData(Protocol.Equipment_Sell)]
     [InlineData(Protocol.Arena_EnterBattle)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -113,6 +113,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquer)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
+    [InlineData(Protocol.Raid_List)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -34,6 +34,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.MemoryLobby_UpdateLobbyMode)]
     [InlineData(Protocol.MemoryLobby_Interact)]
     [InlineData(Protocol.Sticker_Login)]
+    [InlineData(Protocol.Sticker_Lobby)]
     [InlineData(Protocol.SkipHistory_List)]
     [InlineData(Protocol.SkipHistory_Save)]
     [InlineData(Protocol.Character_List)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -40,6 +40,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Notification_LobbyCheck)]
     [InlineData(Protocol.ContentSweep_MultiSweepPresetList)]
     [InlineData(Protocol.OpenCondition_List)]
+    [InlineData(Protocol.OpenCondition_Set)]
     [InlineData(Protocol.Item_Lock)]
     [InlineData(Protocol.Equipment_Lock)]
     [InlineData(Protocol.ClearDeck_List)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -60,6 +60,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Dismiss)]
     [InlineData(Protocol.Clan_Search)]
     [InlineData(Protocol.Clan_MemberList)]
+    [InlineData(Protocol.Clan_Member)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -96,6 +96,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Craft_RewardAll)]
     [InlineData(Protocol.Craft_ShiftingBeginProcess)]
     [InlineData(Protocol.Craft_ShiftingCompleteProcess)]
+    [InlineData(Protocol.Craft_ShiftingCompleteProcessAll)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -47,6 +47,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
+    [InlineData(Protocol.Friend_SetIdCard)]
     [InlineData(Protocol.Billing_PurchaseListByYostar)]
     [InlineData(Protocol.Billing_TransactionStartByYostar)]
     [InlineData(Protocol.Billing_TransactionEndByYostar)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -81,6 +81,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_DeployEchelon)]
     [InlineData(Protocol.Scenario_WithdrawEchelon)]
     [InlineData(Protocol.Scenario_MapMove)]
+    [InlineData(Protocol.Scenario_EndTurn)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -93,6 +93,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
+    [InlineData(Protocol.EliminateRaid_RankingReward)]
     [InlineData(Protocol.Craft_AutoBeginProcess)]
     [InlineData(Protocol.Craft_CompleteProcessAll)]
     [InlineData(Protocol.Craft_RewardAll)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -38,6 +38,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
     [InlineData(Protocol.Billing_PurchaseListByYostar)]
+    [InlineData(Protocol.Billing_TransactionStartByYostar)]
     [InlineData(Protocol.BattlePass_MissionSingleReward)]
     [InlineData(Protocol.BattlePass_MissionMultipleReward)]
     [InlineData(Protocol.Arena_EnterBattle)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -122,6 +122,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_RewardAll)]
     [InlineData(Protocol.Raid_SeasonReward)]
     [InlineData(Protocol.Raid_RankingReward)]
+    [InlineData(Protocol.Raid_Sweep)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -35,6 +35,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
+    [InlineData(Protocol.Arena_EnterBattle)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -75,6 +75,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_ConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_ConquerWithBattleResult)]
     [InlineData(Protocol.Conquest_ManageBase)]
+    [InlineData(Protocol.Conquest_UpgradeBase)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -63,6 +63,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Member)]
     [InlineData(Protocol.Clan_Applicant)]
     [InlineData(Protocol.Clan_CancelApply)]
+    [InlineData(Protocol.Clan_Permit)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -95,6 +95,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Craft_CompleteProcessAll)]
     [InlineData(Protocol.Craft_RewardAll)]
     [InlineData(Protocol.Craft_ShiftingBeginProcess)]
+    [InlineData(Protocol.Craft_ShiftingCompleteProcess)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -26,6 +26,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_CurrencySync)]
     [InlineData(Protocol.Account_BirthDay)]
     [InlineData(Protocol.Account_SetCheckAdultAgree)]
+    [InlineData(Protocol.Account_VerifyCheckAdultAgree)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -29,6 +29,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_VerifyCheckAdultAgree)]
     [InlineData(Protocol.Account_DismissRepurchasablePopup)]
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
+    [InlineData(Protocol.MemoryLobby_List)]
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -31,6 +31,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
+    [InlineData(Protocol.Audit_GachaStatistics)]
     [InlineData(Protocol.Account_CheckYostar)]
     [InlineData(Protocol.Account_PassCheck)]
     [InlineData(Protocol.Account_DetachNexon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -62,6 +62,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Billing_TransactionEndByYostar)]
     [InlineData(Protocol.BattlePass_MissionSingleReward)]
     [InlineData(Protocol.BattlePass_MissionMultipleReward)]
+    [InlineData(Protocol.Item_Sell)]
     [InlineData(Protocol.Equipment_Sell)]
     [InlineData(Protocol.Arena_EnterBattle)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -33,6 +33,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.MemoryLobby_SetMain)]
     [InlineData(Protocol.MemoryLobby_UpdateLobbyMode)]
     [InlineData(Protocol.MemoryLobby_Interact)]
+    [InlineData(Protocol.Sticker_Login)]
     [InlineData(Protocol.SkipHistory_List)]
     [InlineData(Protocol.SkipHistory_Save)]
     [InlineData(Protocol.Character_List)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -81,6 +81,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_ReceiveCalculateRewards)]
     [InlineData(Protocol.Conquest_ErosionBattleStart)]
     [InlineData(Protocol.Conquest_ErosionBattleResult)]
+    [InlineData(Protocol.Conquest_EventObjectBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -33,6 +33,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
     [InlineData(Protocol.ContentSweep_MultiSweepPresetList)]
+    [InlineData(Protocol.Equipment_Lock)]
     [InlineData(Protocol.ClearDeck_List)]
     [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -84,6 +84,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_EndTurn)]
     [InlineData(Protocol.Scenario_EnterTactic)]
     [InlineData(Protocol.Scenario_TacticResult)]
+    [InlineData(Protocol.Scenario_Retreat)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -64,6 +64,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Applicant)]
     [InlineData(Protocol.Clan_CancelApply)]
     [InlineData(Protocol.Clan_Permit)]
+    [InlineData(Protocol.Clan_Kick)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -54,6 +54,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Campaign_WithdrawEchelon)]
     [InlineData(Protocol.Clan_Login)]
     [InlineData(Protocol.Clan_Create)]
+    [InlineData(Protocol.Clan_Join)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -34,6 +34,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]
     [InlineData(Protocol.Character_FavorGrowth)]
+    [InlineData(Protocol.Character_SetCostume)]
     [InlineData(Protocol.Cafe_Travel)]
     [InlineData(Protocol.Audit_GachaStatistics)]
     [InlineData(Protocol.Account_CheckYostar)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -72,6 +72,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_GetInfo)]
     [InlineData(Protocol.Conquest_Check)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
+    [InlineData(Protocol.Conquest_MainStoryCheck)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -47,6 +47,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
+    [InlineData(Protocol.Friend_Remove)]
     [InlineData(Protocol.Friend_Search)]
     [InlineData(Protocol.Friend_GetFriendDetailedInfo)]
     [InlineData(Protocol.Friend_SetIdCard)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -82,6 +82,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_ErosionBattleStart)]
     [InlineData(Protocol.Conquest_ErosionBattleResult)]
     [InlineData(Protocol.Conquest_EventObjectBattleStart)]
+    [InlineData(Protocol.Conquest_EventObjectBattleResult)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -37,6 +37,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
+    [InlineData(Protocol.BattlePass_MissionSingleReward)]
     [InlineData(Protocol.Arena_EnterBattle)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -39,6 +39,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.MultiFloorRaid_Login)]
     [InlineData(Protocol.Notification_LobbyCheck)]
     [InlineData(Protocol.ContentSweep_MultiSweepPresetList)]
+    [InlineData(Protocol.OpenCondition_List)]
     [InlineData(Protocol.Item_Lock)]
     [InlineData(Protocol.Equipment_Lock)]
     [InlineData(Protocol.ClearDeck_List)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -78,6 +78,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleStart)]
+    [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -92,6 +92,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
     [InlineData(Protocol.Craft_AutoBeginProcess)]
+    [InlineData(Protocol.Craft_CompleteProcessAll)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -83,6 +83,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_ErosionBattleResult)]
     [InlineData(Protocol.Conquest_EventObjectBattleStart)]
     [InlineData(Protocol.Conquest_EventObjectBattleResult)]
+    [InlineData(Protocol.Conquest_TakeEventObject)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -44,6 +44,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_CompleteList)]
     [InlineData(Protocol.Item_Lock)]
     [InlineData(Protocol.Equipment_Lock)]
+    [InlineData(Protocol.ResetableContent_Get)]
     [InlineData(Protocol.ClearDeck_List)]
     [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -69,6 +69,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Confer)]
     [InlineData(Protocol.Clan_Setting)]
     [InlineData(Protocol.Clan_ChatLog)]
+    [InlineData(Protocol.Conquest_GetInfo)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -31,6 +31,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
+    [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]
     [InlineData(Protocol.Cafe_Travel)]
     [InlineData(Protocol.Audit_GachaStatistics)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -25,6 +25,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_Auth2)]
     [InlineData(Protocol.Account_CurrencySync)]
     [InlineData(Protocol.Account_BirthDay)]
+    [InlineData(Protocol.Account_SetCheckAdultAgree)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -116,6 +116,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_List)]
     [InlineData(Protocol.Raid_Search)]
     [InlineData(Protocol.Raid_Share)]
+    [InlineData(Protocol.Raid_Detail)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -41,6 +41,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.ContentSweep_MultiSweepPresetList)]
     [InlineData(Protocol.OpenCondition_List)]
     [InlineData(Protocol.OpenCondition_Set)]
+    [InlineData(Protocol.Raid_CompleteList)]
     [InlineData(Protocol.Item_Lock)]
     [InlineData(Protocol.Equipment_Lock)]
     [InlineData(Protocol.ClearDeck_List)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -52,6 +52,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Character_SetCostume)]
     [InlineData(Protocol.Cafe_Travel)]
     [InlineData(Protocol.Audit_GachaStatistics)]
+    [InlineData(Protocol.Recipe_Craft)]
     [InlineData(Protocol.Account_CheckYostar)]
     [InlineData(Protocol.Account_PassCheck)]
     [InlineData(Protocol.Account_DetachNexon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -80,6 +80,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_NormalizeEchelon)]
     [InlineData(Protocol.Conquest_ReceiveCalculateRewards)]
     [InlineData(Protocol.Conquest_ErosionBattleStart)]
+    [InlineData(Protocol.Conquest_ErosionBattleResult)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -66,6 +66,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Permit)]
     [InlineData(Protocol.Clan_Kick)]
     [InlineData(Protocol.Clan_Confer)]
+    [InlineData(Protocol.Clan_Setting)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -120,6 +120,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_BattleUpdate)]
     [InlineData(Protocol.Raid_Reward)]
     [InlineData(Protocol.Raid_RewardAll)]
+    [InlineData(Protocol.Raid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -29,6 +29,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_VerifyCheckAdultAgree)]
     [InlineData(Protocol.Account_DismissRepurchasablePopup)]
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
+    [InlineData(Protocol.Account_CheckYostar)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -38,6 +38,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
     [InlineData(Protocol.BattlePass_MissionSingleReward)]
+    [InlineData(Protocol.BattlePass_MissionMultipleReward)]
     [InlineData(Protocol.Arena_EnterBattle)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -32,6 +32,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
+    [InlineData(Protocol.ContentSweep_MultiSweepPresetList)]
     [InlineData(Protocol.ClearDeck_List)]
     [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -71,6 +71,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_ChatLog)]
     [InlineData(Protocol.Conquest_GetInfo)]
     [InlineData(Protocol.Conquest_Check)]
+    [InlineData(Protocol.Conquest_Conquer)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     public void TheProtocolHasAHandler(Protocol protocol)

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -27,6 +27,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_BirthDay)]
     [InlineData(Protocol.Account_SetCheckAdultAgree)]
     [InlineData(Protocol.Account_VerifyCheckAdultAgree)]
+    [InlineData(Protocol.Account_DismissRepurchasablePopup)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -77,6 +77,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_ManageBase)]
     [InlineData(Protocol.Conquest_UpgradeBase)]
     [InlineData(Protocol.Conquest_DeployEchelon)]
+    [InlineData(Protocol.Conquest_NormalizeEchelon)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -59,6 +59,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Quit)]
     [InlineData(Protocol.Clan_Dismiss)]
     [InlineData(Protocol.Clan_Search)]
+    [InlineData(Protocol.Clan_MemberList)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -98,6 +98,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Craft_ShiftingCompleteProcess)]
     [InlineData(Protocol.Craft_ShiftingCompleteProcessAll)]
     [InlineData(Protocol.Craft_ShiftingReward)]
+    [InlineData(Protocol.Craft_ShiftingRewardAll)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -80,6 +80,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_ConfirmMainStage)]
     [InlineData(Protocol.Scenario_DeployEchelon)]
     [InlineData(Protocol.Scenario_WithdrawEchelon)]
+    [InlineData(Protocol.Scenario_MapMove)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -53,6 +53,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]
     [InlineData(Protocol.Clan_Login)]
+    [InlineData(Protocol.Clan_Create)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -65,6 +65,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_CancelApply)]
     [InlineData(Protocol.Clan_Permit)]
     [InlineData(Protocol.Clan_Kick)]
+    [InlineData(Protocol.Clan_Confer)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -114,6 +114,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
     [InlineData(Protocol.Raid_List)]
+    [InlineData(Protocol.Raid_Search)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -61,6 +61,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Search)]
     [InlineData(Protocol.Clan_MemberList)]
     [InlineData(Protocol.Clan_Member)]
+    [InlineData(Protocol.Clan_Applicant)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -70,6 +70,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Setting)]
     [InlineData(Protocol.Clan_ChatLog)]
     [InlineData(Protocol.Conquest_GetInfo)]
+    [InlineData(Protocol.Conquest_Check)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -51,6 +51,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Friend_DeclineFriendRequest)]
     [InlineData(Protocol.Friend_CancelFriendRequest)]
     [InlineData(Protocol.Friend_Remove)]
+    [InlineData(Protocol.Friend_Block)]
     [InlineData(Protocol.Friend_Search)]
     [InlineData(Protocol.Friend_GetFriendDetailedInfo)]
     [InlineData(Protocol.Friend_SetIdCard)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -119,6 +119,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_Detail)]
     [InlineData(Protocol.Raid_BattleUpdate)]
     [InlineData(Protocol.Raid_Reward)]
+    [InlineData(Protocol.Raid_RewardAll)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -32,6 +32,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.MemoryLobby_List)]
     [InlineData(Protocol.MemoryLobby_SetMain)]
     [InlineData(Protocol.MemoryLobby_UpdateLobbyMode)]
+    [InlineData(Protocol.MemoryLobby_Interact)]
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -31,6 +31,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
     [InlineData(Protocol.Account_CheckYostar)]
     [InlineData(Protocol.Account_PassCheck)]
+    [InlineData(Protocol.Account_DetachNexon)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -117,6 +117,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_Search)]
     [InlineData(Protocol.Raid_Share)]
     [InlineData(Protocol.Raid_Detail)]
+    [InlineData(Protocol.Raid_BattleUpdate)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -83,6 +83,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Item_Sell)]
     [InlineData(Protocol.Equipment_Sell)]
     [InlineData(Protocol.Arena_EnterBattle)]
+    [InlineData(Protocol.TimeAttackDungeon_Sweep)]
     [InlineData(Protocol.Scenario_EnterMainStage)]
     [InlineData(Protocol.Scenario_ConfirmMainStage)]
     [InlineData(Protocol.Scenario_DeployEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -52,6 +52,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Friend_CancelFriendRequest)]
     [InlineData(Protocol.Friend_Remove)]
     [InlineData(Protocol.Friend_Block)]
+    [InlineData(Protocol.Friend_Unblock)]
     [InlineData(Protocol.Friend_Search)]
     [InlineData(Protocol.Friend_GetFriendDetailedInfo)]
     [InlineData(Protocol.Friend_SetIdCard)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -23,6 +23,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Craft_List)]
     [InlineData(Protocol.Craft_SelectNode)]
     [InlineData(Protocol.Account_Auth2)]
+    [InlineData(Protocol.Account_CurrencySync)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -22,6 +22,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Mission_MultipleReward)]
     [InlineData(Protocol.Craft_List)]
     [InlineData(Protocol.Craft_SelectNode)]
+    [InlineData(Protocol.Account_Auth2)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -47,6 +47,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
+    [InlineData(Protocol.Friend_GetFriendDetailedInfo)]
     [InlineData(Protocol.Friend_SetIdCard)]
     [InlineData(Protocol.Billing_PurchaseListByYostar)]
     [InlineData(Protocol.Billing_TransactionStartByYostar)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -97,6 +97,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Craft_ShiftingBeginProcess)]
     [InlineData(Protocol.Craft_ShiftingCompleteProcess)]
     [InlineData(Protocol.Craft_ShiftingCompleteProcessAll)]
+    [InlineData(Protocol.Craft_ShiftingReward)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -30,6 +30,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DismissRepurchasablePopup)]
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
     [InlineData(Protocol.MemoryLobby_List)]
+    [InlineData(Protocol.MemoryLobby_SetMain)]
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -33,6 +33,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_PassCheck)]
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
+    [InlineData(Protocol.Account_Reset)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -55,6 +55,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Login)]
     [InlineData(Protocol.Clan_Create)]
     [InlineData(Protocol.Clan_Join)]
+    [InlineData(Protocol.Clan_AutoJoin)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -32,6 +32,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
+    [InlineData(Protocol.ClearDeck_List)]
     [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]
     [InlineData(Protocol.Character_FavorGrowth)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -95,6 +95,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]
     [InlineData(Protocol.EliminateRaid_LimitedReward)]
+    [InlineData(Protocol.EliminateRaid_Sweep)]
     [InlineData(Protocol.Craft_AutoBeginProcess)]
     [InlineData(Protocol.Craft_CompleteProcessAll)]
     [InlineData(Protocol.Craft_RewardAll)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -31,6 +31,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
     [InlineData(Protocol.MemoryLobby_List)]
     [InlineData(Protocol.MemoryLobby_SetMain)]
+    [InlineData(Protocol.MemoryLobby_UpdateLobbyMode)]
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -29,6 +29,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_VerifyCheckAdultAgree)]
     [InlineData(Protocol.Account_DismissRepurchasablePopup)]
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
+    [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
     [InlineData(Protocol.Campaign_Heal)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -52,6 +52,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]
+    [InlineData(Protocol.Clan_Login)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -82,6 +82,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_WithdrawEchelon)]
     [InlineData(Protocol.Scenario_MapMove)]
     [InlineData(Protocol.Scenario_EndTurn)]
+    [InlineData(Protocol.Scenario_EnterTactic)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -39,6 +39,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_Reset)]
     [InlineData(Protocol.Billing_PurchaseListByYostar)]
     [InlineData(Protocol.Billing_TransactionStartByYostar)]
+    [InlineData(Protocol.Billing_TransactionEndByYostar)]
     [InlineData(Protocol.BattlePass_MissionSingleReward)]
     [InlineData(Protocol.BattlePass_MissionMultipleReward)]
     [InlineData(Protocol.Arena_EnterBattle)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -78,6 +78,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Arena_EnterBattle)]
     [InlineData(Protocol.Scenario_EnterMainStage)]
     [InlineData(Protocol.Scenario_ConfirmMainStage)]
+    [InlineData(Protocol.Scenario_DeployEchelon)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -86,6 +86,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_TacticResult)]
     [InlineData(Protocol.Scenario_Retreat)]
     [InlineData(Protocol.Scenario_Portal)]
+    [InlineData(Protocol.Scenario_RestartMainStage)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -31,6 +31,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
+    [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]
     [InlineData(Protocol.Cafe_Travel)]
     [InlineData(Protocol.Audit_GachaStatistics)]
     [InlineData(Protocol.Account_CheckYostar)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -118,6 +118,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_Share)]
     [InlineData(Protocol.Raid_Detail)]
     [InlineData(Protocol.Raid_BattleUpdate)]
+    [InlineData(Protocol.Raid_Reward)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -47,6 +47,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
+    [InlineData(Protocol.Friend_AcceptFriendRequest)]
     [InlineData(Protocol.Friend_Remove)]
     [InlineData(Protocol.Friend_Search)]
     [InlineData(Protocol.Friend_GetFriendDetailedInfo)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -48,6 +48,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
     [InlineData(Protocol.Friend_AcceptFriendRequest)]
+    [InlineData(Protocol.Friend_DeclineFriendRequest)]
     [InlineData(Protocol.Friend_Remove)]
     [InlineData(Protocol.Friend_Search)]
     [InlineData(Protocol.Friend_GetFriendDetailedInfo)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -115,6 +115,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryConquerWithBattleResult)]
     [InlineData(Protocol.Raid_List)]
     [InlineData(Protocol.Raid_Search)]
+    [InlineData(Protocol.Raid_Share)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -37,6 +37,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DetachNexon)]
     [InlineData(Protocol.Account_RequestBirthdayMail)]
     [InlineData(Protocol.Account_Reset)]
+    [InlineData(Protocol.Billing_PurchaseListByYostar)]
     [InlineData(Protocol.BattlePass_MissionSingleReward)]
     [InlineData(Protocol.BattlePass_MissionMultipleReward)]
     [InlineData(Protocol.Arena_EnterBattle)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -121,6 +121,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_Reward)]
     [InlineData(Protocol.Raid_RewardAll)]
     [InlineData(Protocol.Raid_SeasonReward)]
+    [InlineData(Protocol.Raid_RankingReward)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -79,6 +79,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_EnterMainStage)]
     [InlineData(Protocol.Scenario_ConfirmMainStage)]
     [InlineData(Protocol.Scenario_DeployEchelon)]
+    [InlineData(Protocol.Scenario_WithdrawEchelon)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -57,6 +57,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.ContentSweep_SetMultiSweepPresetName)]
     [InlineData(Protocol.Character_FavorGrowth)]
     [InlineData(Protocol.Character_SetCostume)]
+    [InlineData(Protocol.TTS_GetFile)]
     [InlineData(Protocol.Cafe_Travel)]
     [InlineData(Protocol.Audit_GachaStatistics)]
     [InlineData(Protocol.Recipe_Craft)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -32,6 +32,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_CheckYostar)]
     [InlineData(Protocol.Account_PassCheck)]
     [InlineData(Protocol.Account_DetachNexon)]
+    [InlineData(Protocol.Account_RequestBirthdayMail)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -70,6 +70,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_Setting)]
     [InlineData(Protocol.Clan_ChatLog)]
     [InlineData(Protocol.Conquest_GetInfo)]
+    [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -87,6 +87,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Scenario_Retreat)]
     [InlineData(Protocol.Scenario_Portal)]
     [InlineData(Protocol.Scenario_RestartMainStage)]
+    [InlineData(Protocol.Scenario_SkipMainStage)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -24,6 +24,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Craft_SelectNode)]
     [InlineData(Protocol.Account_Auth2)]
     [InlineData(Protocol.Account_CurrencySync)]
+    [InlineData(Protocol.Account_BirthDay)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -123,6 +123,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Raid_SeasonReward)]
     [InlineData(Protocol.Raid_RankingReward)]
     [InlineData(Protocol.Raid_Sweep)]
+    [InlineData(Protocol.Raid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_GetBestTeam)]
     [InlineData(Protocol.EliminateRaid_SeasonReward)]
     [InlineData(Protocol.EliminateRaid_RankingReward)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -35,6 +35,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.MemoryLobby_Interact)]
     [InlineData(Protocol.Sticker_Login)]
     [InlineData(Protocol.Sticker_Lobby)]
+    [InlineData(Protocol.Sticker_UseSticker)]
     [InlineData(Protocol.SkipHistory_List)]
     [InlineData(Protocol.SkipHistory_Save)]
     [InlineData(Protocol.Character_List)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -46,6 +46,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Arena_EnterBattle)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
+    [InlineData(Protocol.Campaign_WithdrawEchelon)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -34,6 +34,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.MemoryLobby_UpdateLobbyMode)]
     [InlineData(Protocol.MemoryLobby_Interact)]
     [InlineData(Protocol.SkipHistory_List)]
+    [InlineData(Protocol.SkipHistory_Save)]
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -49,6 +49,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_Reset)]
     [InlineData(Protocol.Friend_AcceptFriendRequest)]
     [InlineData(Protocol.Friend_DeclineFriendRequest)]
+    [InlineData(Protocol.Friend_CancelFriendRequest)]
     [InlineData(Protocol.Friend_Remove)]
     [InlineData(Protocol.Friend_Search)]
     [InlineData(Protocol.Friend_GetFriendDetailedInfo)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -73,6 +73,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_Check)]
     [InlineData(Protocol.Conquest_Conquer)]
     [InlineData(Protocol.Conquest_ConquerWithBattleStart)]
+    [InlineData(Protocol.Conquest_ConquerWithBattleResult)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -78,6 +78,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_UpgradeBase)]
     [InlineData(Protocol.Conquest_DeployEchelon)]
     [InlineData(Protocol.Conquest_NormalizeEchelon)]
+    [InlineData(Protocol.Conquest_ReceiveCalculateRewards)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -33,6 +33,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Arena_Login)]
     [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]
+    [InlineData(Protocol.Character_FavorGrowth)]
     [InlineData(Protocol.Cafe_Travel)]
     [InlineData(Protocol.Audit_GachaStatistics)]
     [InlineData(Protocol.Account_CheckYostar)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -74,6 +74,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_Conquer)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
+    [InlineData(Protocol.Conquest_MainStoryConquer)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -45,6 +45,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.BattlePass_MissionMultipleReward)]
     [InlineData(Protocol.Arena_EnterBattle)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
+    [InlineData(Protocol.Campaign_Portal)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -29,6 +29,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_VerifyCheckAdultAgree)]
     [InlineData(Protocol.Account_DismissRepurchasablePopup)]
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
+    [InlineData(Protocol.Arena_Login)]
     [InlineData(Protocol.Account_CheckYostar)]
     [InlineData(Protocol.Account_PassCheck)]
     [InlineData(Protocol.Account_DetachNexon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -30,6 +30,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Account_DismissRepurchasablePopup)]
     [InlineData(Protocol.Account_ReportXignCodeCheater)]
     [InlineData(Protocol.Account_CheckYostar)]
+    [InlineData(Protocol.Account_PassCheck)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -37,6 +37,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
     [InlineData(Protocol.MultiFloorRaid_Login)]
+    [InlineData(Protocol.Notification_LobbyCheck)]
     [InlineData(Protocol.ContentSweep_MultiSweepPresetList)]
     [InlineData(Protocol.Item_Lock)]
     [InlineData(Protocol.Equipment_Lock)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -33,6 +33,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]
     [InlineData(Protocol.ContentSweep_MultiSweepPresetList)]
+    [InlineData(Protocol.Item_Lock)]
     [InlineData(Protocol.Equipment_Lock)]
     [InlineData(Protocol.ClearDeck_List)]
     [InlineData(Protocol.Campaign_Heal)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -77,6 +77,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Equipment_Sell)]
     [InlineData(Protocol.Arena_EnterBattle)]
     [InlineData(Protocol.Scenario_EnterMainStage)]
+    [InlineData(Protocol.Scenario_ConfirmMainStage)]
     [InlineData(Protocol.Campaign_ConfirmTutorialStage)]
     [InlineData(Protocol.Campaign_Portal)]
     [InlineData(Protocol.Campaign_WithdrawEchelon)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -79,6 +79,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_DeployEchelon)]
     [InlineData(Protocol.Conquest_NormalizeEchelon)]
     [InlineData(Protocol.Conquest_ReceiveCalculateRewards)]
+    [InlineData(Protocol.Conquest_ErosionBattleStart)]
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -94,6 +94,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Craft_AutoBeginProcess)]
     [InlineData(Protocol.Craft_CompleteProcessAll)]
     [InlineData(Protocol.Craft_RewardAll)]
+    [InlineData(Protocol.Craft_ShiftingBeginProcess)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -53,6 +53,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.ClearDeck_List)]
     [InlineData(Protocol.Campaign_Heal)]
     [InlineData(Protocol.Campaign_PurchasePlayCountHardStage)]
+    [InlineData(Protocol.System_Version)]
     [InlineData(Protocol.ContentSweep_SetMultiSweepPresetName)]
     [InlineData(Protocol.Character_FavorGrowth)]
     [InlineData(Protocol.Character_SetCostume)]

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -76,6 +76,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Conquest_MainStoryGetInfo)]
     [InlineData(Protocol.Conquest_MainStoryCheck)]
     [InlineData(Protocol.Conquest_MainStoryConquer)]
+    [InlineData(Protocol.Conquest_MainStoryConquerWithBattleStart)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -62,6 +62,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.Clan_MemberList)]
     [InlineData(Protocol.Clan_Member)]
     [InlineData(Protocol.Clan_Applicant)]
+    [InlineData(Protocol.Clan_CancelApply)]
     public void TheProtocolHasAHandler(Protocol protocol)
     {
         Assert.Contains(protocol, HandledProtocols);

--- a/Shittim-Server.Tests/ProtocolRegistrationTests.cs
+++ b/Shittim-Server.Tests/ProtocolRegistrationTests.cs
@@ -33,6 +33,7 @@ public class ProtocolRegistrationTests
     [InlineData(Protocol.MemoryLobby_SetMain)]
     [InlineData(Protocol.MemoryLobby_UpdateLobbyMode)]
     [InlineData(Protocol.MemoryLobby_Interact)]
+    [InlineData(Protocol.SkipHistory_List)]
     [InlineData(Protocol.Character_List)]
     [InlineData(Protocol.Attachment_Get)]
     [InlineData(Protocol.Arena_Login)]

--- a/Shittim-Server.Tests/RaidClearGateTests.cs
+++ b/Shittim-Server.Tests/RaidClearGateTests.cs
@@ -1,0 +1,41 @@
+using Schale.Data.GameModel;
+using Schale.MX.GameLogic.DBModel;
+using Shittim_Server.Services;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+// A raid row exists from the moment its battle is created and EndBossBattle writes Clear even for a give-up,
+// so the reward and sweep paths gate on the bosses being dead rather than on RaidState.
+public class RaidClearGateTests
+{
+    private static RaidDBServer Raid(params long[] bossHp) => new()
+    {
+        RaidBossDBs = bossHp.Select((hp, i) => new RaidBossDBServer { BossIndex = i, BossCurrentHP = hp }).ToList()
+    };
+
+    [Fact]
+    public void AFreshRaidIsNotCleared()
+    {
+        Assert.False(RaidService.IsCleared(Raid(10_000_000)));
+    }
+
+    [Fact]
+    public void ARaidWithOneBossStandingIsNotCleared()
+    {
+        Assert.False(RaidService.IsCleared(Raid(0, 0, 4200)));
+    }
+
+    [Fact]
+    public void EveryBossDeadIsCleared()
+    {
+        Assert.True(RaidService.IsCleared(Raid(0, 0, 0)));
+    }
+
+    [Fact]
+    public void ARaidWithNoBossRowsIsNotCleared()
+    {
+        // An empty boss list would otherwise pass All() vacuously and make every raid rewardable.
+        Assert.False(RaidService.IsCleared(Raid()));
+    }
+}

--- a/Shittim-Server.Tests/RaidRewardHelperTests.cs
+++ b/Shittim-Server.Tests/RaidRewardHelperTests.cs
@@ -1,0 +1,73 @@
+using Schale.FlatData;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Services;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+public class RaidRewardHelperTests
+{
+    [Fact]
+    public void ClaimableRewardsFollowTheGauge()
+    {
+        var rewardIds = new List<long> { 10, 20, 30 };
+        var thresholds = new List<long> { 100, 500, 1000 };
+
+        Assert.Equal([10, 20], RaidService.ClaimableSeasonRewardIds(rewardIds, thresholds, 600, []));
+        Assert.Equal([20], RaidService.ClaimableSeasonRewardIds(rewardIds, thresholds, 600, [10]));
+        Assert.Empty(RaidService.ClaimableSeasonRewardIds(rewardIds, thresholds, 50, []));
+        Assert.Equal([10, 20, 30], RaidService.ClaimableSeasonRewardIds(rewardIds, thresholds, 1000, []));
+    }
+
+    [Fact]
+    public void ClaimableRewardsAreBoundedByTheShorterColumn()
+    {
+        var rewardIds = new List<long> { 10, 20, 30 };
+        var thresholds = new List<long> { 100 };
+
+        Assert.Equal([10], RaidService.ClaimableSeasonRewardIds(rewardIds, thresholds, 9999, []));
+        Assert.Empty(RaidService.ClaimableSeasonRewardIds(null, thresholds, 9999, []));
+        Assert.Empty(RaidService.ClaimableSeasonRewardIds(rewardIds, null, 9999, []));
+    }
+
+    [Fact]
+    public void ParcelColumnsZipWhenAligned()
+    {
+        var parcels = RaidService.ZipParcelColumns(
+            [ParcelType.Currency, ParcelType.Item],
+            [1, 2],
+            [100, 200]);
+
+        Assert.Equal(2, parcels.Count);
+        Assert.Equal(ParcelType.Currency, parcels[0].Type);
+        Assert.Equal(1, parcels[0].Id);
+        Assert.Equal(100, parcels[0].Amount);
+        Assert.Equal(ParcelType.Item, parcels[1].Type);
+        Assert.Equal(200, parcels[1].Amount);
+    }
+
+    [Fact]
+    public void RaggedParcelColumnsAreRejected()
+    {
+        Assert.Throws<WebAPIException>(() =>
+            RaidService.ZipParcelColumns([ParcelType.Currency, ParcelType.Item], [1], [100, 200]));
+    }
+
+    [Fact]
+    public void StageRewardRollKeepsGuaranteedRowsAndTheirParcels()
+    {
+        var rows = new List<RaidStageRewardExcelT>
+        {
+            new() { ClearStageRewardProb = 0, ClearStageRewardParcelType = ParcelType.Currency, ClearStageRewardParcelUniqueID = 5, ClearStageRewardAmount = 50 },
+            new() { ClearStageRewardProb = 10000, ClearStageRewardParcelType = ParcelType.Item, ClearStageRewardParcelUniqueID = 7, ClearStageRewardAmount = 3 },
+        };
+
+        var rolled = RaidService.RollStageRewards(rows);
+
+        Assert.Equal(2, rolled.Count);
+        Assert.Equal(ParcelType.Currency, rolled[0].Type);
+        Assert.Equal(5, rolled[0].Id);
+        Assert.Equal(50, rolled[0].Amount);
+        Assert.Equal(ParcelType.Item, rolled[1].Type);
+    }
+}

--- a/Shittim-Server.Tests/RaidSeasonChangeTests.cs
+++ b/Shittim-Server.Tests/RaidSeasonChangeTests.cs
@@ -82,9 +82,9 @@ public class RaidSeasonChangeTests : IDisposable
         using (var db = NewContext())
         {
             var lobby = await manager.GetUpdatedLobby(db, db.GetAccount(1));
-            var season = _excels.GetTable<RaidSeasonManageExcelT>().First(x => x.SeasonId == 4);
             Assert.Equal("Chesed_Outdoor", lobby.PlayableHighestDifficulty.Keys.Single());
-            Assert.Equal(season.SeasonRewardId, lobby.ReceiveRewardIds);
+            // A new season starts with nothing claimed, so Raid_SeasonReward can pay out.
+            Assert.Empty(lobby.ReceiveRewardIds);
         }
     }
 

--- a/Shittim-Server.Tests/ResetableContentWindowTests.cs
+++ b/Shittim-Server.Tests/ResetableContentWindowTests.cs
@@ -1,0 +1,48 @@
+using Schale.Data.GameModel;
+using Schale.FlatData;
+using Shittim_Server.Services;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+public class ResetableContentWindowTests
+{
+    private static readonly TimeSpan Window = TimeSpan.FromDays(60);
+
+    [Fact]
+    public void ACounterAccumulatesWithinTheWindow()
+    {
+        var account = new AccountDBServer();
+
+        ResetableContentService.Bump(account, ResetContentType.StarategyMapHeal, 0, Window);
+        ResetableContentService.Bump(account, ResetContentType.StarategyMapHeal, 0, Window);
+
+        Assert.Equal(2, ResetableContentService.LiveValue(account, ResetContentType.StarategyMapHeal, 0, Window));
+    }
+
+    [Fact]
+    public void ACounterResetsOnceTheWindowPasses()
+    {
+        var account = new AccountDBServer();
+        ResetableContentService.Bump(account, ResetContentType.HardStagePlay, 1111103, Window);
+
+        account.GameSettings.ResetableContents[0].LastUpdateTime =
+            account.GameSettings.ServerDateTime() - Window - TimeSpan.FromMinutes(1);
+
+        Assert.Equal(0, ResetableContentService.LiveValue(account, ResetContentType.HardStagePlay, 1111103, Window));
+        Assert.Empty(ResetableContentService.LiveValues(account, Window));
+    }
+
+    [Fact]
+    public void CountersAreKeyedByTypeAndContent()
+    {
+        var account = new AccountDBServer();
+
+        ResetableContentService.Bump(account, ResetContentType.HardStagePlay, 1111103, Window);
+        ResetableContentService.Bump(account, ResetContentType.HardStagePlay, 1222203, Window, delta: 3);
+
+        Assert.Equal(1, ResetableContentService.LiveValue(account, ResetContentType.HardStagePlay, 1111103, Window));
+        Assert.Equal(3, ResetableContentService.LiveValue(account, ResetContentType.HardStagePlay, 1222203, Window));
+        Assert.Equal(0, ResetableContentService.LiveValue(account, ResetContentType.StarategyMapHeal, 1111103, Window));
+    }
+}

--- a/Shittim-Server.Tests/ShiftingCraftTests.cs
+++ b/Shittim-Server.Tests/ShiftingCraftTests.cs
@@ -1,0 +1,227 @@
+using AutoMapper;
+using BlueArchiveAPI.Services;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.DependencyInjection;
+using Schale.Data;
+using Schale.Data.GameModel;
+using Schale.FlatData;
+using Schale.MappingProfiles;
+using Schale.MX.GameLogic.DBModel;
+using Schale.MX.GameLogic.Parcel;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core.NetworkProtocol.Handlers;
+using Shittim_Server.Services;
+using Xunit;
+
+namespace Shittim_Server.Tests;
+
+// The shifting-craft track and the batch node-craft variants.
+public class ShiftingCraftTests
+{
+    [Fact]
+    public async Task AutoBeginProcessStartsAFullyResolvedCraft()
+    {
+        using var db = NewContext();
+        var account = NewAccount(db);
+
+        var request = new CraftAutoBeginProcessRequest
+        {
+            SessionKey = Key(account),
+            Count = 1,
+            PresetSlotDB = new CraftPresetSlotDB
+            {
+                PresetNodeDBs =
+                [
+                    new CraftPresetNodeDB { NodeTier = CraftNodeTier.Node01, IsActivated = true },
+                    new CraftPresetNodeDB { NodeTier = CraftNodeTier.Node02, IsActivated = true },
+                    new CraftPresetNodeDB { NodeTier = CraftNodeTier.Node03, IsActivated = true }
+                ]
+            }
+        };
+
+        var response = await Handler().AutoBeginProcess(db, request, new CraftAutoBeginProcessResponse());
+
+        Assert.NotNull(response.CraftInfoDBs);
+        var started = Assert.Single(response.CraftInfoDBs);
+        Assert.NotEqual(DateTime.MaxValue, started.StartTime);
+        Assert.True(started.EndTime > started.StartTime);
+
+        var slot = db.CraftInfos.Single(x => x.AccountServerId == account.ServerId);
+        Assert.Contains(slot.Nodes!, x => x.NodeId != 0 && x.CraftNodeResult?.ParcelInfo != null);
+    }
+
+    [Fact]
+    public async Task RewardAllClaimsTheFinishedSlotsAndKeepsTheRest()
+    {
+        using var db = NewContext();
+        var account = NewAccount(db);
+        var now = account.GameSettings.ServerDateTime();
+
+        db.CraftInfos.Add(new CraftInfoDBServer
+        {
+            AccountServerId = account.ServerId,
+            SlotSequence = 1,
+            StartTime = now.AddHours(-3),
+            EndTime = now.AddMinutes(-1),
+            Nodes =
+            [
+                new CraftNodeDB
+                {
+                    NodeTier = CraftNodeTier.Node01,
+                    NodeId = 21,
+                    CraftNodeResult = new CraftNodeResult
+                    {
+                        NodeTier = CraftNodeTier.Node01,
+                        ParcelInfo = new ParcelInfo
+                        {
+                            Key = new ParcelKeyPair { Type = ParcelType.Item, Id = 2 },
+                            Amount = 3
+                        }
+                    }
+                }
+            ]
+        });
+        db.CraftInfos.Add(new CraftInfoDBServer
+        {
+            AccountServerId = account.ServerId,
+            SlotSequence = 2,
+            StartTime = now.AddHours(-1),
+            EndTime = now.AddHours(1),
+            Nodes = []
+        });
+        db.SaveChanges();
+
+        var response = await Handler().RewardAll(db, new CraftRewardAllRequest { SessionKey = Key(account) }, new CraftRewardAllResponse());
+
+        Assert.NotNull(response.ParcelResultDB);
+        Assert.NotNull(response.CraftInfos);
+        Assert.Equal(2, Assert.Single(response.CraftInfos).SlotSequence);
+        Assert.Equal(2, db.CraftInfos.Single(x => x.AccountServerId == account.ServerId).SlotSequence);
+        Assert.Equal(3, db.GetAccountItems(account.ServerId).Single(x => x.UniqueId == 2).StackCount);
+    }
+
+    [Fact]
+    public async Task ShiftingCompleteProcessAllFinishesTheRunningSlots()
+    {
+        using var db = NewContext();
+        var account = NewAccount(db);
+        var now = account.GameSettings.ServerDateTime();
+
+        db.ShiftingCraftInfos.Add(new ShiftingCraftInfoDBServer
+        {
+            AccountServerId = account.ServerId,
+            SlotSequence = 1,
+            CraftRecipeId = 1,
+            CraftAmount = 1,
+            StartTime = now.AddHours(-1),
+            EndTime = now.AddHours(2)
+        });
+        db.ShiftingCraftInfos.Add(new ShiftingCraftInfoDBServer
+        {
+            AccountServerId = account.ServerId,
+            SlotSequence = 2,
+            CraftRecipeId = 1,
+            CraftAmount = 1,
+            StartTime = now.AddHours(-2),
+            EndTime = now.AddMinutes(-1)
+        });
+        db.SaveChanges();
+
+        var response = await Handler().ShiftingCompleteProcessAll(
+            db, new CraftShiftingCompleteProcessAllRequest { SessionKey = Key(account) }, new CraftShiftingCompleteProcessAllResponse());
+
+        Assert.NotNull(response.CraftInfoDBs);
+        Assert.Equal(2, response.CraftInfoDBs.Count);
+        Assert.All(
+            db.ShiftingCraftInfos.Where(x => x.AccountServerId == account.ServerId).ToList(),
+            x => Assert.True(x.EndTime <= account.GameSettings.ServerDateTime()));
+    }
+
+    [Fact]
+    public async Task ShiftingRewardBeforeTheEndThrows()
+    {
+        using var db = NewContext();
+        var account = NewAccount(db);
+        var now = account.GameSettings.ServerDateTime();
+
+        db.ShiftingCraftInfos.Add(new ShiftingCraftInfoDBServer
+        {
+            AccountServerId = account.ServerId,
+            SlotSequence = 1,
+            CraftRecipeId = 1,
+            CraftAmount = 1,
+            StartTime = now,
+            EndTime = now.AddHours(1)
+        });
+        db.SaveChanges();
+
+        await Assert.ThrowsAsync<WebAPIException>(() => Handler().ShiftingReward(
+            db, new CraftShiftingRewardRequest { SessionKey = Key(account), SlotId = 1 }, new CraftShiftingRewardResponse()));
+
+        Assert.Single(db.ShiftingCraftInfos.Where(x => x.AccountServerId == account.ServerId));
+    }
+
+    private static readonly ExcelTableService Excels = LoadExcels();
+
+    private static ExcelTableService LoadExcels()
+    {
+        var dir = AppContext.BaseDirectory;
+        while (dir != null && !Directory.Exists(Path.Combine(dir, "Shittim-Server")))
+            dir = Path.GetDirectoryName(dir);
+
+        ExcelTableService.DumpedDir = new[]
+        {
+            Path.Combine(dir!, "Shittim-Server", "Resources", "Dumped"),
+            Path.Combine(dir!, "Shittim-Server", "bin", "Debug", "net10.0", "Resources", "Dumped"),
+            Path.Combine(dir!, "Shittim-Server", "bin", "Release", "net10.0", "Resources", "Dumped"),
+        }.First(Directory.Exists);
+
+        return new ExcelTableService();
+    }
+
+    private static CraftHandler Handler() => new(
+        null!, new FixedSessionService(), Excels, Mapper,
+        new ConsumeHandler(Excels, Mapper), new ParcelHandler(Excels, Mapper), new MissionService(Excels, Mapper));
+
+    private static SessionKey Key(AccountDBServer account) => new() { AccountServerId = account.ServerId, MxToken = "t" };
+
+    private class FixedSessionService : ISessionKeyService
+    {
+        public Task<AccountDBServer> GetAuthenticatedUser(SchaleDataContext context, SessionKey? sessionKey) =>
+            Task.FromResult(context.Accounts.Single(x => x.ServerId == sessionKey!.AccountServerId));
+
+        public Task<SessionKey?> GenerateSession(long publisherAccountId, string? customToken = null) => throw new NotSupportedException();
+        public bool ValidateRequest(RequestPacket request) => true;
+        public void RevokeSession(long userId) { }
+        public int PurgeExpiredSessions(TimeSpan maxInactivity) => 0;
+    }
+
+    private static SchaleDataContext NewContext()
+    {
+        var path = Path.Combine(Path.GetTempPath(), $"shittim-shiftingcrafttest-{Guid.NewGuid():N}.sqlite3");
+        var context = new SchaleDataContext(
+            new DbContextOptionsBuilder<SchaleDataContext>().UseSqlite($"Data Source={path}").Options);
+
+        context.Database.EnsureCreated();
+        return context;
+    }
+
+    private static AccountDBServer NewAccount(SchaleDataContext db)
+    {
+        var account = new AccountDBServer { ServerId = 1, Nickname = "Sensei1" };
+        db.Accounts.Add(account);
+        db.Currencies.Add(new AccountCurrencyDBServer(1));
+        db.SaveChanges();
+        return account;
+    }
+
+    private static readonly IMapper Mapper = BuildMapper();
+
+    private static IMapper BuildMapper()
+    {
+        var services = new ServiceCollection();
+        services.AddLogging();
+        services.AddAutoMapper(cfg => { }, typeof(GameModelsMappingProfile).Assembly);
+        return services.BuildServiceProvider().GetRequiredService<IMapper>();
+    }
+}

--- a/Shittim-Server.Tests/ShopPurchaseLimitTests.cs
+++ b/Shittim-Server.Tests/ShopPurchaseLimitTests.cs
@@ -12,15 +12,22 @@ namespace Shittim_Server.Tests;
 public class ShopPurchaseLimitTests
 {
     [Theory]
-    [InlineData(0)]
     [InlineData(-1)]
     [InlineData(-30)]
     [InlineData(long.MinValue)]
-    public void ANonPositiveCountIsRefused(long count)
+    public void ANegativeCountIsRefused(long count)
     {
-        // A non-positive count is what inverted the consume into a grant.
-        var ex = Assert.Throws<WebAPIException>(() => ShopHandler.ValidatePurchaseCount(count));
+        // A negative count is what inverted the consume into a grant.
+        var ex = Assert.Throws<WebAPIException>(() => ShopHandler.NormalizePurchaseCount(count));
         Assert.Equal(WebAPIErrorCode.ShopInvalidCostOrReward, ex.ErrorCode);
+    }
+
+    [Fact]
+    public void AnAbsentCountBuysOne()
+    {
+        // A request that omits PurchaseCount deserializes to 0. Refusing it made single-unit buys fail with
+        // ShopInvalidCostOrReward while the same item bought in bulk went through.
+        Assert.Equal(1, ShopHandler.NormalizePurchaseCount(0));
     }
 
     [Theory]
@@ -29,8 +36,8 @@ public class ShopPurchaseLimitTests
     [InlineData(ShopHandler.MaxPurchaseCountPerRequest + 1)]
     public void ACountBigEnoughToOverflowTheCostIsRefused(long count)
     {
-        // The bound has to be two-sided: `> 0` alone still allows a count large enough that cost * count overflows to a negative number, which re-opens the same hole.
-        var ex = Assert.Throws<WebAPIException>(() => ShopHandler.ValidatePurchaseCount(count));
+        // The bound has to be two-sided: `>= 0` alone still allows a count large enough that cost * count overflows to a negative number, which re-opens the same hole.
+        var ex = Assert.Throws<WebAPIException>(() => ShopHandler.NormalizePurchaseCount(count));
         Assert.Equal(WebAPIErrorCode.ShopInvalidCostOrReward, ex.ErrorCode);
     }
 
@@ -41,7 +48,7 @@ public class ShopPurchaseLimitTests
     [InlineData(ShopHandler.MaxPurchaseCountPerRequest)]
     public void RealisticCountsPass(long count)
     {
-        ShopHandler.ValidatePurchaseCount(count);
+        Assert.Equal(count, ShopHandler.NormalizePurchaseCount(count));
     }
 
     [Fact]

--- a/Shittim-Server/Commands/CharacterCommand.cs
+++ b/Shittim-Server/Commands/CharacterCommand.cs
@@ -104,8 +104,9 @@ namespace Shittim.Commands
                 case "modify":
                     if (Target == "all")
                     {
+                        // ModifyAllCharacters messages success or failure itself; a second unconditional
+                        // "Modified All Characters" here reported success even when the input was rejected.
                         await CharacterGM.ModifyAllCharacters(connection, Options, ModifyParams);
-                        await connection.SendChatMessage("Modified All Characters");
                     }
                     else if (isValidId)
                     {

--- a/Shittim-Server/Configuration/ConfigType/ServerConfig.cs
+++ b/Shittim-Server/Configuration/ConfigType/ServerConfig.cs
@@ -49,6 +49,9 @@ namespace BlueArchiveAPI.Configuration.ConfigType
         public bool UseCustomExcel { get; set; } = false;
         // Fills every cafe with Koyuki and swaps the lobby banner list for the single webview banner. Off means stock random visitors and no banners.
         public bool KoyukiIncident { get; set; } = false;
+        // Days before resetable content counters (hard-stage play purchases, strategy-map heals, ...) reset.
+        // Official resets these daily; the long default is this server's deliberately generous limit.
+        public int ResetableContentResetDays { get; set; } = 60;
         public bool AutoCheckVersion { get; set; } = true;
         public bool AutoUpdateVersion { get; set; } = true;
         public bool AutoUpdateResources { get; set; } = true;

--- a/Shittim-Server/Controllers/ManagementController.cs
+++ b/Shittim-Server/Controllers/ManagementController.cs
@@ -185,14 +185,6 @@ public class ManagementController : ControllerBase
         }
     }
 
-    // SQL identifiers cannot be parameterized, so any name that is interpolated into a statement is required to be a bare identifier first.
-    private static bool IsPlainSqlIdentifier(string name)
-    {
-        return !string.IsNullOrEmpty(name)
-            && (char.IsLetter(name[0]) || name[0] == '_')
-            && name.All(c => char.IsLetterOrDigit(c) || c == '_');
-    }
-
     public class DeleteAccountRequest { public long ServerId { get; set; } }
 
     [HttpPost("account/delete")]
@@ -204,22 +196,7 @@ public class ManagementController : ControllerBase
             if (!await db.Accounts.AnyAsync(x => x.ServerId == request.ServerId))
                 return NotFound(new { error = "Account not found" });
 
-            // Cascade by hand: wipe every child table that carries an AccountServerId column, discovered from the SQLite catalogue so we never miss one.
-            var tables = await db.Database
-                .SqlQueryRaw<string>(
-                    "SELECT m.name AS Value FROM sqlite_master m " +
-                    "JOIN pragma_table_info(m.name) p ON 1=1 " +
-                    "WHERE m.type='table' AND p.name='AccountServerId'")
-                .ToListAsync();
-
-            foreach (var table in tables.Distinct())
-            {
-                if (!IsPlainSqlIdentifier(table))
-                    continue;
-
-                await db.Database.ExecuteSqlRawAsync(
-                    $"DELETE FROM \"{table}\" WHERE AccountServerId = {{0}}", request.ServerId);
-            }
+            await AccountInitializationService.WipeAccountData(db, request.ServerId);
 
             await db.Database.ExecuteSqlRawAsync(
                 "DELETE FROM \"Accounts\" WHERE ServerId = {0}", request.ServerId);

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -700,6 +700,54 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_CheckYostar)]
+    public async Task<AccountCheckYostarResponse> CheckYostar(
+        SchaleDataContext db,
+        AccountCheckYostarRequest request,
+        AccountCheckYostarResponse response)
+    {
+        // The Yostar twin of CheckNexon: same find-or-create by publisher id, same crypto handshake out.
+        var publisherId = request.UID;
+        var token = request.YostarToken ?? "";
+        if (publisherId == 0 && !string.IsNullOrEmpty(request.EnterTicket))
+        {
+            var parts = Encoding.UTF8.GetString(Convert.FromBase64String(request.EnterTicket)).Split('/');
+            publisherId = long.Parse(parts[0]);
+            if (parts.Length > 1) token = parts[1];
+        }
+
+        var user = await db.UserAccounts.FirstOrDefaultAsync(u => u.NpSN == publisherId);
+        if (user == null)
+        {
+            db.UserAccounts.Add(new UserAccount { Uid = -1, NpSN = publisherId, NpToken = token });
+            var newAccount = new AccountDBServer(publisherId);
+            db.Accounts.Add(newAccount);
+            await db.SaveChangesAsync();
+
+            user = await db.UserAccounts.FirstAsync(u => u.NpSN == publisherId);
+            var account = await db.Accounts.FirstAsync(a => a.PublisherAccountId == publisherId);
+            user.Uid = account.ServerId;
+            await AccountInitializationService.InitializeCompleteAccount(db, account);
+            await db.SaveChangesAsync();
+        }
+        else if (user.NpToken != token)
+        {
+            user.NpToken = token;
+            await db.SaveChangesAsync();
+        }
+
+        var sessionKey = await _sessionService.GenerateSession(publisherId);
+        var gatewayCrypto = GatewaySessionCryptoBuilder.Build(request.ClientGeneratedKey, request.ClientGeneratedIV);
+
+        response.ResultState = 1;
+        response.SessionKey = sessionKey;
+        response.EncryptedKey = gatewayCrypto.EncryptedKey;
+        response.SignedKey = gatewayCrypto.SignedKey;
+        response.EncryptedIV = gatewayCrypto.EncryptedIV;
+        response.SignedIV = gatewayCrypto.SignedIV;
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -778,6 +778,57 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_RequestBirthdayMail)]
+    public async Task<AccountRequestBirthdayMailResponse> RequestBirthdayMail(
+        SchaleDataContext db,
+        AccountRequestBirthdayMailRequest request,
+        AccountRequestBirthdayMailResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (account.BirthDay == null
+            || account.BirthDay.Value.Month != request.Birthday.Month
+            || account.BirthDay.Value.Day != request.Birthday.Day)
+        {
+            throw new WebAPIException(WebAPIErrorCode.AccountUpdateBirthdayFailed,
+                "Requested birthday does not match the account's");
+        }
+
+        var now = account.GameSettings.ServerDateTime();
+        // One birthday mail per year; the client only offers the flow on the birthday itself.
+        if (account.GameSettings.LastBirthdayMailYear == now.Year)
+            return response;
+
+        var constCommon = _excelService.GetTable<ConstCommonExcelT>().First();
+        db.Mails.Add(new MailDBServer
+        {
+            AccountServerId = account.ServerId,
+            Type = MailType.BirthdayMail,
+            SendDate = now,
+            ExpireDate = now.AddDays(constCommon.BirthdayMailRemainDate > 0 ? constCommon.BirthdayMailRemainDate : 7),
+            ParcelInfos =
+            [
+                new ParcelInfo
+                {
+                    Key = new ParcelKeyPair
+                    {
+                        Type = constCommon.BirthdayMailParcelType,
+                        Id = constCommon.BirthdayMailParcelId
+                    },
+                    Amount = constCommon.BirthdayMailParcelAmount
+                }
+            ],
+            RemainParcelInfos = new List<ParcelInfo>()
+        });
+
+        account.GameSettings.LastBirthdayMailYear = now.Year;
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+        MailNotificationService.MarkNewMail(account.ServerId);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -490,41 +490,7 @@ public class AccountHandler : ProtocolHandlerBase
             DailyRecordIdInMailList = []
         };
 
-        var battlePasses = db.BattlePasses.Where(x => x.AccountServerId == account.ServerId && x.PurchaseGroupId != 0).ToList();
-        var battlePassProductList = new List<BattlePassProductPurchaseDB>();
-
-        if (battlePasses.Any())
-        {
-            var productExcels = _excelService.GetTable<ProductExcelT>();
-            var shopCashExcels = _excelService.GetTable<ShopCashExcelT>();
-
-            foreach (var bp in battlePasses)
-            {
-                // A battle pass is sold through a ProductExcel row carrying a ProductBattlePass (28) parcel; the parcel id at that slot is the BattlePassId.
-                var battlePassProducts = productExcels.Where(x => x.ParcelType.Contains(ParcelType.ProductBattlePass)).ToList();
-
-                ProductExcelT product = battlePassProducts.FirstOrDefault(x => {
-                    var idx = x.ParcelType.IndexOf(ParcelType.ProductBattlePass);
-                    return idx >= 0 && idx < x.ParcelId.Count && x.ParcelId[idx] == bp.BattlePassId;
-                });
-
-                if (product != null)
-                {
-                    var shopCash = shopCashExcels.FirstOrDefault(x => x.CashProductId == product.Id);
-                    if (shopCash != null)
-                    {
-                        battlePassProductList.Add(new BattlePassProductPurchaseDB
-                        {
-                            ProductId = shopCash.Id, 
-                            BattlePassId = bp.BattlePassId,
-                            PurchaseBattlePassGroupId = bp.PurchaseGroupId
-                        });
-                        _logger.LogDebug("[AccountHandler] Mapped BP {BattlePassId} -> ShopCash {ShopCashId}", bp.BattlePassId, shopCash.Id);
-                    }
-                }
-            }
-        }
-        billingResponse.BattlePassProductList = battlePassProductList;
+        billingResponse.BattlePassProductList = BillingHandler.BuildBattlePassProductList(db, account, _excelService);
         response.BillingPurchaseListByNexonResponse = billingResponse;
 
         response.EventContentPermanentListResponse = new EventContentPermanentListResponse
@@ -592,7 +558,7 @@ public class AccountHandler : ProtocolHandlerBase
     }
 
     // 8-char A-Z code in the official FriendCode format, stable per account.
-    private static string BuildFriendCode(long accountServerId)
+    internal static string BuildFriendCode(long accountServerId)
     {
         var hash = System.Security.Cryptography.SHA256.HashData(
             Encoding.UTF8.GetBytes($"shittim-friend:{accountServerId}"));

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -622,6 +622,18 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_CurrencySync)]
+    public async Task<AccountCurrencySyncResponse> CurrencySync(
+        SchaleDataContext db,
+        AccountCurrencySyncRequest request,
+        AccountCurrencySyncResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.AccountCurrencyDB = db.GetAccountCurrencies(account.ServerId).FirstMapTo(_mapper);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -634,6 +634,25 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_BirthDay)]
+    public async Task<AccountBirthDayResponse> BirthDay(
+        SchaleDataContext db,
+        AccountBirthDayRequest request,
+        AccountBirthDayResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // Official allows setting a birthday exactly once.
+        if (account.BirthDay == null)
+        {
+            account.BirthDay = request.BirthDay;
+            await db.SaveChangesAsync();
+        }
+
+        response.AccountDB = account.ToMap(_mapper);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -680,6 +680,16 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_DismissRepurchasablePopup)]
+    public async Task<AccountDismissRepurchasablePopupResponse> DismissRepurchasablePopup(
+        SchaleDataContext db,
+        AccountDismissRepurchasablePopupRequest request,
+        AccountDismissRepurchasablePopupResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -448,6 +448,11 @@ public class AccountHandler : ProtocolHandlerBase
             AccountClanMemberDB = new ClanMemberDB { AccountId = account.ServerId }
         };
 
+        // The client caches this list for the MomoTalk screen, so a student without a row here has no conversation
+        // to open until the next login.
+        MomoTalkService.SyncOutlines(db, account, _excelService.GetTable<AcademyMessangerExcelT>());
+        await db.SaveChangesAsync();
+
         var momoTalkOutlines = db.GetAccountMomoTalkOutLines(account.ServerId).ToList();
         response.MomotalkOutlineResponse = new MomoTalkOutLineResponse
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -668,6 +668,18 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_VerifyCheckAdultAgree)]
+    public async Task<AccountVerifyAdultCheckResponse> VerifyCheckAdultAgree(
+        SchaleDataContext db,
+        AccountVerifyAdultCheckRequest request,
+        AccountVerifyAdultCheckResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.CheckAdultAgree = account.GameSettings.CheckAdultAgree;
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -690,6 +690,16 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_ReportXignCodeCheater)]
+    public async Task<AccountReportXignCodeCheaterResponse> ReportXignCodeCheater(
+        SchaleDataContext db,
+        AccountReportXignCodeCheaterRequest request,
+        AccountReportXignCodeCheaterResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -764,6 +764,20 @@ public class AccountHandler : ProtocolHandlerBase
         return Task.FromResult(response);
     }
 
+    [ProtocolHandler(Protocol.Account_DetachNexon)]
+    public async Task<AccountDetachNexonResponse> DetachNexon(
+        SchaleDataContext db,
+        AccountDetachNexonRequest request,
+        AccountDetachNexonResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // Cosmetic success only: on this server CheckNexon logs in BY the publisher id, so actually severing
+        // the link would brick the only login path.
+        response.ResultState = 1;
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -653,6 +653,21 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_SetCheckAdultAgree)]
+    public async Task<AccountSetAdultCheckResponse> SetCheckAdultAgree(
+        SchaleDataContext db,
+        AccountSetAdultCheckRequest request,
+        AccountSetAdultCheckResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        account.GameSettings.CheckAdultAgree = request.CheckAdultAgree;
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -748,6 +748,22 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_PassCheck)]
+    public Task<AccountPassCheckResponse> PassCheck(
+        SchaleDataContext db,
+        AccountPassCheckRequest request,
+        AccountPassCheckResponse response)
+    {
+        // Pre-session dev-id check; the only server obligation is the gateway crypto handshake.
+        var gatewayCrypto = GatewaySessionCryptoBuilder.Build(request.ClientGeneratedKey, request.ClientGeneratedIV);
+
+        response.EncryptedKey = gatewayCrypto.EncryptedKey;
+        response.SignedKey = gatewayCrypto.SignedKey;
+        response.EncryptedIV = gatewayCrypto.EncryptedIV;
+        response.SignedIV = gatewayCrypto.SignedIV;
+        return Task.FromResult(response);
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -829,6 +829,43 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_Reset)]
+    public async Task<AccountResetResponse> Reset(
+        SchaleDataContext db,
+        AccountResetRequest request,
+        AccountResetResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var accountId = account.ServerId;
+        var publisherId = account.PublisherAccountId;
+
+        await AccountInitializationService.WipeAccountData(db, accountId);
+
+        db.ChangeTracker.Clear();
+        var fresh = await db.Accounts.FirstAsync(x => x.ServerId == accountId);
+        var template = new AccountDBServer(publisherId ?? accountId);
+        fresh.Nickname = string.Empty;
+        fresh.CallName = null;
+        fresh.Comment = null;
+        fresh.State = template.State;
+        fresh.Level = template.Level;
+        fresh.Exp = 0;
+        fresh.LobbyMode = 0;
+        fresh.RepresentCharacterServerId = 0;
+        fresh.MemoryLobbyUniqueId = 0;
+        fresh.BirthDay = null;
+        fresh.UnReadMailCount = 0;
+        fresh.GameSettings = new();
+        fresh.ContentInfo = template.ContentInfo;
+        fresh.BattleSummaries = new List<BattleSummaryDB>();
+        fresh.RaidSummaries = new List<RaidSummaryDB>();
+
+        await AccountInitializationService.InitializeCompleteAccount(db, fresh);
+        await db.SaveChangesAsync();
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AccountHandler.cs
@@ -612,6 +612,16 @@ public class AccountHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Account_Auth2)]
+    public async Task<AccountAuth2Response> Auth2(
+        SchaleDataContext db,
+        AccountAuth2Request request,
+        AccountAuth2Response response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Account_CheckAccountLevelReward)]
     public async Task<CheckAccountLevelRewardResponse> CheckLevelReward(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ArenaHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ArenaHandler.cs
@@ -143,7 +143,7 @@ public class ArenaHandler : ProtocolHandlerBase
             NickName = account.Nickname ?? "Player",
             Rank = 1,
             Level = account.Level,
-            RepresentCharacterUniqueId = account.RepresentCharacterServerId,
+            RepresentCharacterUniqueId = FriendHandler.RepresentCharacterUniqueId(db, account),
             AccountAttachmentDB = db.GetAccountAttachments(account.ServerId).FirstMapTo(_mapper),
             TeamSettingDB = ArenaService.CreateArenaTeamSetting(db, account, _mapper, false)
         };

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ArenaHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ArenaHandler.cs
@@ -141,6 +141,77 @@ public class ArenaHandler : ProtocolHandlerBase
         return response;
     }
 
+    // The single-shot ancestor of EnterBattlePart1+Part2, still sent by older client builds: build the two
+    // sides like Part1 (no OpponentRank in this request, so rank 1), then charge the ticket like Part2.
+    [ProtocolHandler(Protocol.Arena_EnterBattle)]
+    public async Task<ArenaEnterBattleResponse> EnterBattle(
+        SchaleDataContext db,
+        ArenaEnterBattleRequest request,
+        ArenaEnterBattleResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var attackingUser = new ArenaUserDB
+        {
+            AccountServerId = account.ServerId,
+            NickName = account.Nickname ?? "Player",
+            Rank = 1,
+            Level = account.Level,
+            RepresentCharacterUniqueId = FriendHandler.RepresentCharacterUniqueId(db, account),
+            AccountAttachmentDB = db.GetAccountAttachments(account.ServerId).FirstMapTo(_mapper),
+            TeamSettingDB = ArenaService.CreateArenaTeamSetting(db, account, _mapper, false)
+        };
+
+        var opponentAccount = await db.Accounts.FirstOrDefaultAsync(x => x.ServerId == request.OpponentAccountServerId);
+        var defendingUser = opponentAccount != null
+            ? ArenaService.CreateArenaUser(
+                opponentAccount.ServerId,
+                opponentAccount.RepresentCharacterServerId,
+                opponentAccount.Nickname ?? "Opponent",
+                1,
+                opponentAccount.Level,
+                ArenaService.CreateArenaTeamSetting(db, opponentAccount, _mapper, true))
+            : ArenaService.CreateArenaUser(
+                request.OpponentAccountServerId,
+                10065,
+                "Dummy Opponent",
+                1,
+                90,
+                ArenaService.DummyTeamFormation);
+
+        response.ArenaBattleDB = new ArenaBattleDB
+        {
+            Season = 1,
+            Group = 1,
+            BattleStartTime = account.GameSettings.ServerDateTime(),
+            Seed = DateTimeOffset.UtcNow.ToUnixTimeSeconds(),
+            AttackingUserDB = attackingUser,
+            DefendingUserDB = defendingUser
+        };
+        response.ArenaPlayerInfoDB = BuildPlayerInfo(account);
+
+        var ticketCost = _excelService.GetTable<ConstArenaExcelT>().FirstOrDefault()?.TicketCost ?? 1;
+        if (ticketCost <= 0) ticketCost = 1;
+
+        var currency = db.Currencies.FirstOrDefault(x => x.AccountServerId == account.ServerId);
+        if (currency != null
+            && currency.CurrencyDict.TryGetValue(CurrencyTypes.ArenaTicket, out var tickets)
+            && tickets >= ticketCost)
+        {
+            var resolver = await _parcelHandler.BuildParcel(
+                db, account,
+                new ParcelResult(ParcelType.Currency, (long)CurrencyTypes.ArenaTicket, ticketCost),
+                isConsume: true);
+            await db.SaveChangesAsync();
+            response.AccountCurrencyDB = resolver.ParcelResult.AccountCurrencyDB;
+        }
+
+        response.AccountCurrencyDB ??= db.GetAccountCurrencies(account.ServerId).FirstMapTo(_mapper);
+        // VictoryRewards/SeasonRewards/AllTimeRewards stay null: the client settles rewards via Arena_BattleResult.
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Arena_EnterBattlePart1)]
     public async Task<ArenaEnterBattlePart1Response> EnterBattlePart1(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ArenaHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ArenaHandler.cs
@@ -87,6 +87,18 @@ public class ArenaHandler : ProtocolHandlerBase
         return now;
     }
 
+    [ProtocolHandler(Protocol.Arena_Login)]
+    public async Task<ArenaLoginResponse> Login(
+        SchaleDataContext db,
+        ArenaLoginRequest request,
+        ArenaLoginResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.ArenaPlayerInfoDB = BuildPlayerInfo(account);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Arena_EnterLobby)]
     public async Task<ArenaEnterLobbyResponse> EnterLobby(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AttachmentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AttachmentHandler.cs
@@ -25,6 +25,18 @@ public class AttachmentHandler : ProtocolHandlerBase
         _mapper = mapper;
     }
 
+    [ProtocolHandler(Protocol.Attachment_Get)]
+    public async Task<AttachmentGetResponse> Get(
+        SchaleDataContext db,
+        AttachmentGetRequest request,
+        AttachmentGetResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.AccountAttachmentDB = db.GetAccountAttachments(account.ServerId).FirstMapTo(_mapper);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Attachment_EmblemList)]
     public async Task<AttachmentEmblemListResponse> EmblemList(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AuditHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AuditHandler.cs
@@ -1,0 +1,19 @@
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class AuditHandler : ProtocolHandlerBase
+{
+    private readonly ISessionKeyService _sessionService;
+
+    public AuditHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService) : base(registry)
+    {
+        _sessionService = sessionService;
+    }
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/AuditHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/AuditHandler.cs
@@ -16,4 +16,17 @@ public class AuditHandler : ProtocolHandlerBase
         _sessionService = sessionService;
     }
 
+    [ProtocolHandler(Protocol.Audit_GachaStatistics)]
+    public async Task<AuditGachaStatisticsResponse> GachaStatistics(
+        SchaleDataContext db,
+        AuditGachaStatisticsRequest request,
+        AuditGachaStatisticsResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // The disclosure screen aggregates pulls across the player base; there is no population here.
+        response.GachaResult = new Dictionary<long, long>();
+
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/BattlePassHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/BattlePassHandler.cs
@@ -217,4 +217,41 @@ public class BattlePassHandler : ProtocolHandlerBase
 
         return response;
     }
+
+    private async Task<BattlePassDBServer> GetOrCreatePass(SchaleDataContext db, AccountDBServer account, long battlePassId)
+    {
+        var battlePass = await db.BattlePasses
+            .FirstOrDefaultAsync(x => x.AccountServerId == account.ServerId && x.BattlePassId == battlePassId);
+        if (battlePass != null)
+            return battlePass;
+
+        battlePass = new BattlePassDBServer
+        {
+            AccountServerId = account.ServerId,
+            BattlePassId = battlePassId,
+            PassLevel = 1,
+            LastWeeklyPassExpLimitRefreshDate = account.GameSettings.ServerDateTime()
+        };
+        db.BattlePasses.Add(battlePass);
+        await db.SaveChangesAsync();
+        return battlePass;
+    }
+
+    // Battle-pass missions carry no reward parcels - the reward IS pass exp (BattlePassMissionExcel has only BattlePassExpAmount).
+    private void ApplyPassExp(BattlePassDBServer battlePass, long amount)
+    {
+        battlePass.PassExp += amount;
+        battlePass.WeeklyPassExp += amount;
+
+        var need = _excelTableService.GetTable<BattlePassInfoExcelT>()
+            .FirstOrDefault(x => x.Id == battlePass.BattlePassId)?.NextLvNeedExp ?? 0;
+        if (need <= 0)
+            return;
+
+        while (battlePass.PassExp >= need)
+        {
+            battlePass.PassExp -= need;
+            battlePass.PassLevel++;
+        }
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/BattlePassHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/BattlePassHandler.cs
@@ -264,6 +264,55 @@ public class BattlePassHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.BattlePass_MissionMultipleReward)]
+    public async Task<BattlePassMissionMultipleRewardResponse> MissionMultipleReward(
+        SchaleDataContext db,
+        BattlePassMissionMultipleRewardRequest request,
+        BattlePassMissionMultipleRewardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var excelById = _excelTableService.GetTable<BattlePassMissionExcelT>()
+            .Where(x => x.BattlePassId == request.BattlePassId)
+            .GroupBy(x => x.Id)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var claimable = await db.MissionProgresses
+            .Where(x => x.AccountServerId == account.ServerId && x.Complete)
+            .ToListAsync();
+        claimable = claimable.Where(x => excelById.ContainsKey(x.MissionUniqueId)).ToList();
+
+        var battlePass = await GetOrCreatePass(db, account, request.BattlePassId);
+        response.AddedHistoryDBs = [];
+        response.ParcelResultDB = new ParcelResultDB();
+        response.BattlePassInfo = battlePass;
+
+        if (claimable.Count == 0)
+            return response;
+
+        var completeTime = account.GameSettings.ServerDateTime();
+        foreach (var progress in claimable)
+        {
+            ApplyPassExp(battlePass, excelById[progress.MissionUniqueId].BattlePassExpAmount);
+            db.MissionHistories.Add(new MissionHistoryDBServer
+            {
+                AccountServerId = account.ServerId,
+                MissionUniqueId = progress.MissionUniqueId,
+                CompleteTime = completeTime
+            });
+            response.AddedHistoryDBs.Add(new MissionHistoryDB
+            {
+                MissionUniqueId = progress.MissionUniqueId,
+                CompleteTime = completeTime
+            });
+        }
+
+        db.MissionProgresses.RemoveRange(claimable);
+        await db.SaveChangesAsync();
+
+        return response;
+    }
+
     private async Task<BattlePassDBServer> GetOrCreatePass(SchaleDataContext db, AccountDBServer account, long battlePassId)
     {
         var battlePass = await db.BattlePasses

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/BattlePassHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/BattlePassHandler.cs
@@ -218,6 +218,52 @@ public class BattlePassHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.BattlePass_MissionSingleReward)]
+    public async Task<BattlePassMissionSingleRewardResponse> MissionSingleReward(
+        SchaleDataContext db,
+        BattlePassMissionSingleRewardRequest request,
+        BattlePassMissionSingleRewardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var excel = _excelTableService.GetTable<BattlePassMissionExcelT>()
+                .FirstOrDefault(x => x.BattlePassId == request.BattlePassId && x.Id == request.MissionUniqueId)
+            ?? throw new WebAPIException(WebAPIErrorCode.DataEntityNotFound,
+                $"Battle pass mission {request.MissionUniqueId} not found");
+
+        var progress = await db.MissionProgresses
+                .FirstOrDefaultAsync(x => x.AccountServerId == account.ServerId && x.MissionUniqueId == request.MissionUniqueId)
+            ?? throw new WebAPIException(WebAPIErrorCode.MissionRewardInvalid,
+                $"Mission {request.MissionUniqueId} has no progress row");
+
+        if (!progress.Complete)
+            throw new WebAPIException(WebAPIErrorCode.MissionCannotComplete,
+                $"Mission {request.MissionUniqueId} is not complete");
+
+        var battlePass = await GetOrCreatePass(db, account, request.BattlePassId);
+        ApplyPassExp(battlePass, excel.BattlePassExpAmount);
+
+        db.MissionProgresses.Remove(progress);
+        var completeTime = account.GameSettings.ServerDateTime();
+        db.MissionHistories.Add(new MissionHistoryDBServer
+        {
+            AccountServerId = account.ServerId,
+            MissionUniqueId = request.MissionUniqueId,
+            CompleteTime = completeTime
+        });
+        await db.SaveChangesAsync();
+
+        response.AddedHistoryDB = new MissionHistoryDB
+        {
+            MissionUniqueId = request.MissionUniqueId,
+            CompleteTime = completeTime
+        };
+        response.ParcelResultDB = new ParcelResultDB();
+        response.BattlePassInfo = battlePass;
+
+        return response;
+    }
+
     private async Task<BattlePassDBServer> GetOrCreatePass(SchaleDataContext db, AccountDBServer account, long battlePassId)
     {
         var battlePass = await db.BattlePasses

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/BillingHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/BillingHandler.cs
@@ -207,4 +207,21 @@ public class BillingHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Billing_PurchaseListByYostar)]
+    public async Task<BillingPurchaseListByYostarResponse> PurchaseListByYostar(
+        SchaleDataContext db,
+        BillingPurchaseListByYostarRequest request,
+        BillingPurchaseListByYostarResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.CountList = [];
+        response.OrderList = [];
+        response.MonthlyProductList = [];
+        response.BlockedProductDBs = [];
+        response.BattlePassProductList = BuildBattlePassProductList(db, account, _excelTableService);
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/BillingHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/BillingHandler.cs
@@ -224,4 +224,32 @@ public class BillingHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Billing_TransactionStartByYostar)]
+    public async Task<BillingTransactionStartByYostarResponse> TransactionStartByYostar(
+        SchaleDataContext db,
+        BillingTransactionStartByYostarRequest request,
+        BillingTransactionStartByYostarResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var shopCash = _excelTableService.GetTable<ShopCashExcelT>().FirstOrDefault(x => x.Id == request.ShopCashId)
+            ?? throw new WebAPIException(WebAPIErrorCode.BillingStartShopCashIdNotFound,
+                $"ShopCash {request.ShopCashId} not found");
+
+        // Monotonic enough for one player; the ticks double as a record of when the order opened.
+        var orderId = account.GameSettings.ServerDateTimeTicks();
+        account.GameSettings.PendingPurchaseOrders[orderId] = shopCash.Id;
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        response.PurchaseCount = 0;
+        response.PurchaseResetDate = DateTime.MinValue;
+        response.PurchaseOrderId = orderId;
+        response.MXSeedKey = "";
+        response.PurchaseServerTag = PurchaseServerTag.Production;
+        response.PurchaseServerCallbackUrl = "";
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/BillingHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/BillingHandler.cs
@@ -27,6 +27,45 @@ public class BillingHandler : ProtocolHandlerBase
         _parcelHandler = parcelHandler;
     }
 
+    // A battle pass is sold through a ProductExcel row carrying a ProductBattlePass parcel; the parcel id
+    // at that slot is the BattlePassId, and billing responses key the purchase by the ShopCash row's id.
+    internal static List<BattlePassProductPurchaseDB> BuildBattlePassProductList(
+        SchaleDataContext db, Schale.Data.GameModel.AccountDBServer account, ExcelTableService excelService)
+    {
+        var battlePasses = db.BattlePasses.Where(x => x.AccountServerId == account.ServerId && x.PurchaseGroupId != 0).ToList();
+        var result = new List<BattlePassProductPurchaseDB>();
+        if (battlePasses.Count == 0)
+            return result;
+
+        var productExcels = excelService.GetTable<ProductExcelT>();
+        var shopCashExcels = excelService.GetTable<ShopCashExcelT>();
+        var battlePassProducts = productExcels.Where(x => x.ParcelType.Contains(ParcelType.ProductBattlePass)).ToList();
+
+        foreach (var bp in battlePasses)
+        {
+            var product = battlePassProducts.FirstOrDefault(x =>
+            {
+                var idx = x.ParcelType.IndexOf(ParcelType.ProductBattlePass);
+                return idx >= 0 && idx < x.ParcelId.Count && x.ParcelId[idx] == bp.BattlePassId;
+            });
+            if (product == null)
+                continue;
+
+            var shopCash = shopCashExcels.FirstOrDefault(x => x.CashProductId == product.Id);
+            if (shopCash == null)
+                continue;
+
+            result.Add(new BattlePassProductPurchaseDB
+            {
+                ProductId = shopCash.Id,
+                BattlePassId = bp.BattlePassId,
+                PurchaseBattlePassGroupId = bp.PurchaseGroupId
+            });
+        }
+
+        return result;
+    }
+
     [ProtocolHandler(Protocol.Billing_PurchaseListByNexon)]
     public async Task<BillingPurchaseListByNexonResponse> PurchaseListByNexon(
         SchaleDataContext db,
@@ -44,60 +83,7 @@ public class BillingHandler : ProtocolHandlerBase
         // Official's standalone response carries this (as [] when empty) and has no IsTeenage key - that's a request-side field.
         response.DailyRecordIdInMailList = [];
         
-        var battlePasses = db.BattlePasses.Where(x => x.AccountServerId == account.ServerId && x.PurchaseGroupId != 0).ToList();
-        var battlePassProductList = new List<BattlePassProductPurchaseDB>();
-
-        if (battlePasses.Any())
-        {
-            var productExcels = _excelTableService.GetTable<ProductExcelT>();
-            var shopCashExcels = _excelTableService.GetTable<ShopCashExcelT>();
-
-            foreach (var bp in battlePasses)
-            {
-                Log.Debug("[BillingHandler] BattlePassId: {BattlePassId}. Total Products: {ProductCount}", bp.BattlePassId, productExcels.Count);
-
-                var battlePassProducts = productExcels.Where(x => x.ParcelType.Contains(ParcelType.ProductBattlePass)).ToList();
-                Log.Debug("[BillingHandler] Found {MatchCount} products containing ProductBattlePass type.", battlePassProducts.Count);
-
-                ProductExcelT product = null;
-                
-                product = battlePassProducts.FirstOrDefault(x => {
-                    var idx = x.ParcelType.IndexOf(ParcelType.ProductBattlePass);
-                    return idx >= 0 && idx < x.ParcelId.Count && x.ParcelId[idx] == bp.BattlePassId;
-                });
-
-                if (product != null)
-                {
-                    var shopCash = shopCashExcels.FirstOrDefault(x => x.CashProductId == product.Id);
-                    
-                    if (shopCash != null)
-                    {
-                        battlePassProductList.Add(new BattlePassProductPurchaseDB
-                        {
-                            ProductId = shopCash.Id, // Billing response expects ShopCashId as ProductId
-                            BattlePassId = bp.BattlePassId,
-                            PurchaseBattlePassGroupId = bp.PurchaseGroupId
-                        });
-                        Log.Debug("[BillingHandler] Mapped BattlePassId {BattlePassId} to ShopCashId {ShopCashId} via ProductId {ProductId}",
-                            bp.BattlePassId, shopCash.Id, product.Id);
-                    }
-                    else
-                    {
-                        Log.Warning("[BillingHandler] ShopCash not found for ProductId: {ProductId} (BattlePassId: {BattlePassId})", product.Id, bp.BattlePassId);
-                    }
-                }
-                else
-                {
-                    Log.Warning("[BillingHandler] No product found for BattlePassId: {BattlePassId} among {CandidateCount} candidates.", bp.BattlePassId, battlePassProducts.Count);
-                }
-            }
-        }
-        else
-        {
-            Log.Debug("[BillingHandler] No BattlePasses found for Account: {AccountServerId} with PurchaseGroupId != 0", account.ServerId);
-        }
-
-        response.BattlePassProductList = battlePassProductList;
+        response.BattlePassProductList = BuildBattlePassProductList(db, account, _excelTableService);
         response.BattlePassIdInMailList = [];
 
         return response;
@@ -220,4 +206,5 @@ public class BillingHandler : ProtocolHandlerBase
 
         return response;
     }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/BillingHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/BillingHandler.cs
@@ -252,4 +252,82 @@ public class BillingHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Billing_TransactionEndByYostar)]
+    public async Task<BillingTransactionEndByYostarResponse> TransactionEndByYostar(
+        SchaleDataContext db,
+        BillingTransactionEndByYostarRequest request,
+        BillingTransactionEndByYostarResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (!account.GameSettings.PendingPurchaseOrders.TryGetValue(request.PurchaseOrderId, out var shopCashId))
+            throw new WebAPIException(WebAPIErrorCode.PaymentNotFoundPurchase,
+                $"Order {request.PurchaseOrderId} not found");
+
+        account.GameSettings.PendingPurchaseOrders.Remove(request.PurchaseOrderId);
+        db.Accounts.Update(account);
+
+        response.CountList = [];
+        response.MonthlyProductList = [];
+        response.BattlePassProductList = [];
+
+        if (request.EndType != BillingTransactionEndType.Success)
+        {
+            await db.SaveChangesAsync();
+            return response;
+        }
+
+        var shopCash = _excelTableService.GetTable<ShopCashExcelT>().FirstOrDefault(x => x.Id == shopCashId)
+            ?? throw new WebAPIException(WebAPIErrorCode.BillingEndShopCashIdNotFound,
+                $"ShopCash {shopCashId} not found");
+        var product = _excelTableService.GetTable<ProductExcelT>().FirstOrDefault(x => x.Id == shopCash.CashProductId)
+            ?? throw new WebAPIException(WebAPIErrorCode.BillingEndShopCashIdNotFound,
+                $"Product {shopCash.CashProductId} not found");
+
+        var count = ShopHandler.AlignedColumnCount(
+            product.ParcelType?.Count, product.ParcelId?.Count, product.ParcelAmount?.Count);
+        var parcels = new List<ParcelInfo>();
+        Schale.Data.GameModel.BattlePassDBServer? purchasedPass = null;
+        for (int i = 0; i < count; i++)
+        {
+            if (product.ParcelType![i] == ParcelType.ProductBattlePass)
+            {
+                var passId = product.ParcelId![i];
+                purchasedPass = db.BattlePasses.FirstOrDefault(x => x.AccountServerId == account.ServerId && x.BattlePassId == passId);
+                if (purchasedPass == null)
+                {
+                    purchasedPass = new Schale.Data.GameModel.BattlePassDBServer
+                    {
+                        AccountServerId = account.ServerId,
+                        BattlePassId = passId,
+                        PassLevel = 1,
+                        LastWeeklyPassExpLimitRefreshDate = account.GameSettings.ServerDateTime()
+                    };
+                    db.BattlePasses.Add(purchasedPass);
+                }
+                // Readers only test PurchaseGroupId != 0 to unlock the paid track.
+                purchasedPass.PurchaseGroupId = shopCash.Id;
+                continue;
+            }
+
+            parcels.Add(new ParcelInfo
+            {
+                Key = new ParcelKeyPair { Type = product.ParcelType[i], Id = product.ParcelId![i] },
+                Amount = product.ParcelAmount![i]
+            });
+        }
+
+        var parcelResultDB = new ParcelResultDB();
+        if (parcels.Count > 0)
+            await _parcelHandler.BuildParcel(db, account, parcels, parcelResultDB);
+
+        await db.SaveChangesAsync();
+
+        response.ParcelResult = parcelResultDB;
+        response.PurchaseCount = 1;
+        response.BattlePassInfo = purchasedPass;
+        response.BattlePassProductList = BuildBattlePassProductList(db, account, _excelTableService);
+
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CafeHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CafeHandler.cs
@@ -5,6 +5,7 @@ using BlueArchiveAPI.Services;
 using Schale.Data;
 using Schale.Data.GameModel;
 using Schale.Data.ModelMapping;
+using Schale.MX.GameLogic.DBModel;
 using Schale.MX.NetworkProtocol;
 using Schale.MX.GameLogic.Parcel;
 using Schale.FlatData;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CafeHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CafeHandler.cs
@@ -37,6 +37,33 @@ public class CafeHandler : ProtocolHandlerBase
         _missionService = missionService;
     }
 
+    [ProtocolHandler(Protocol.Cafe_Travel)]
+    public async Task<CafeTravelResponse> Travel(
+        SchaleDataContext db,
+        CafeTravelRequest request,
+        CafeTravelResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // Single-player server: there is no friend's cafe to visit, so the travel lands in the account's own.
+        var attachment = db.GetAccountAttachments(account.ServerId).FirstOrDefault();
+        response.FriendDB = new FriendDB
+        {
+            AccountId = account.ServerId,
+            Nickname = account.Nickname ?? "Sensei",
+            Level = account.Level,
+            RepresentCharacterUniqueId = FriendHandler.RepresentCharacterUniqueId(db, account),
+            RepresentCharacterCostumeId = FriendHandler.RepresentCharacterUniqueId(db, account),
+            LastConnectTime = account.GameSettings.ServerDateTime(),
+            ComfortValue = 10000,
+            FriendCount = 0,
+            AttachmentDB = attachment != null ? _mapper.Map<AccountAttachmentDB>(attachment) : null
+        };
+        response.CafeDBs = db.GetAccountCafes(account.ServerId).ToMapList(_mapper);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Cafe_Get)]
     public async Task<CafeGetInfoResponse> Get(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignConcentrateHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignConcentrateHandler.cs
@@ -36,6 +36,28 @@ public class CampaignConcentrateHandler : ProtocolHandlerBase
         _logger = logger;
     }
 
+    [ProtocolHandler(Protocol.Campaign_ConfirmTutorialStage)]
+    public async Task<CampaignConfirmTutorialStageResponse> ConfirmTutorialStage(
+        SchaleDataContext db,
+        CampaignConfirmTutorialStageRequest request,
+        CampaignConfirmTutorialStageResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // Get-or-create covers both orders: the tutorial client may or may not have sent a deploy
+        // (which persists the row) before confirming.
+        _ = await _concentrateCampaignManager.GetConcentrateCampaign(db, account, request.StageUniqueId)
+            ?? await _concentrateCampaignManager.CreateConcentrateCampaign(db, account, request.StageUniqueId);
+
+        var stageSave = await _concentrateCampaignManager.StartConcentrateCampaign(db, account, new CampaignConfirmMainStageRequest
+        {
+            StageUniqueId = request.StageUniqueId
+        });
+
+        response.SaveDataDB = ConcentrateCampaignManager.ShapeForWire(stageSave.ToMap(_mapper));
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Campaign_EnterMainStage)]
     public async Task<CampaignEnterMainStageResponse> EnterMainStage(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignConcentrateHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignConcentrateHandler.cs
@@ -76,6 +76,25 @@ public class CampaignConcentrateHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Campaign_WithdrawEchelon)]
+    public async Task<CampaignWithdrawEchelonResponse> WithdrawEchelon(
+        SchaleDataContext db,
+        CampaignWithdrawEchelonRequest request,
+        CampaignWithdrawEchelonResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var (stageSave, echelons) = await _eventContentCampaignManager.WithdrawEchelon(db, account, new EventContentWithdrawEchelonRequest
+        {
+            StageUniqueId = request.StageUniqueId,
+            WithdrawEchelonEntityId = request.WithdrawEchelonEntityId
+        });
+
+        response.SaveDataDB = ConcentrateCampaignManager.ShapeForWire(stageSave.ToMap(_mapper));
+        response.WithdrawEchelonDBs = echelons;
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Campaign_EnterMainStage)]
     public async Task<CampaignEnterMainStageResponse> EnterMainStage(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignConcentrateHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignConcentrateHandler.cs
@@ -17,6 +17,7 @@ public class CampaignConcentrateHandler : ProtocolHandlerBase
 {
     private readonly ISessionKeyService _sessionService;
     private readonly ConcentrateCampaignManager _concentrateCampaignManager;
+    private readonly EventContentCampaignManager _eventContentCampaignManager;
     private readonly IMapper _mapper;
     private readonly ILogger<CampaignConcentrateHandler> _logger;
 
@@ -24,11 +25,13 @@ public class CampaignConcentrateHandler : ProtocolHandlerBase
         IProtocolHandlerRegistry registry,
         ISessionKeyService sessionService,
         ConcentrateCampaignManager concentrateCampaignManager,
+        EventContentCampaignManager eventContentCampaignManager,
         IMapper mapper,
         ILogger<CampaignConcentrateHandler> logger) : base(registry)
     {
         _sessionService = sessionService;
         _concentrateCampaignManager = concentrateCampaignManager;
+        _eventContentCampaignManager = eventContentCampaignManager;
         _mapper = mapper;
         _logger = logger;
     }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignConcentrateHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignConcentrateHandler.cs
@@ -58,6 +58,24 @@ public class CampaignConcentrateHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Campaign_Portal)]
+    public async Task<CampaignPortalResponse> Portal(
+        SchaleDataContext db,
+        CampaignPortalRequest request,
+        CampaignPortalResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var stageSave = await _eventContentCampaignManager.Portal(db, account, new EventContentPortalRequest
+        {
+            StageUniqueId = request.StageUniqueId,
+            EchelonEntityId = request.EchelonEntityId
+        });
+
+        response.CampaignMainStageSaveDB = ConcentrateCampaignManager.ShapeForWire(stageSave.ToMap(_mapper));
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Campaign_EnterMainStage)]
     public async Task<CampaignEnterMainStageResponse> EnterMainStage(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignHandler.cs
@@ -180,6 +180,22 @@ public class CampaignHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Campaign_PurchasePlayCountHardStage)]
+    public async Task<CampaignPurchasePlayCountHardStageResponse> PurchasePlayCountHardStage(
+        SchaleDataContext db,
+        CampaignPurchasePlayCountHardStageRequest request,
+        CampaignPurchasePlayCountHardStageResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var (currency, history) = await _campaignManager.PurchasePlayCountHardStage(db, account, request.StageUniqueId);
+
+        response.AccountCurrencyDB = currency.ToMap(_mapper);
+        response.CampaignStageHistoryDB = history.ToMap(_mapper);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Campaign_RestartMainStage)]
     public async Task<CampaignRestartMainStageResponse> RestartMainStage(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CampaignHandler.cs
@@ -196,6 +196,23 @@ public class CampaignHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Campaign_Heal)]
+    public async Task<CampaignHealResponse> Heal(
+        SchaleDataContext db,
+        CampaignHealRequest request,
+        CampaignHealResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var (currency, save) = await _campaignManager.Heal(
+            db, account, request.CampaignStageUniqueId, request.EchelonIndex, request.CharacterServerId);
+
+        response.AccountCurrencyDB = currency.ToMap(_mapper);
+        response.SaveDataDB = ConcentrateCampaignManager.ShapeForWire(save.ToMap(_mapper));
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Campaign_RestartMainStage)]
     public async Task<CampaignRestartMainStageResponse> RestartMainStage(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CharacterHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CharacterHandler.cs
@@ -37,6 +37,40 @@ public class CharacterHandler : ProtocolHandlerBase
         _parcelHandler = parcelHandler;
     }
 
+    [ProtocolHandler(Protocol.Character_FavorGrowth)]
+    public async Task<CharacterFavorGrowthResponse> FavorGrowth(
+        SchaleDataContext db,
+        CharacterFavorGrowthRequest request,
+        CharacterFavorGrowthResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var character = db.Characters.FirstOrDefault(x =>
+                x.AccountServerId == account.ServerId && x.ServerId == request.TargetCharacterDBId)
+            ?? throw new WebAPIException(WebAPIErrorCode.CharacterNotFound,
+                $"Character {request.TargetCharacterDBId} not found");
+
+        // Same pipeline as the cafe gift: the consume side accumulates the favor exp the items carry,
+        // and the FavorExp parcel applies it (including any rank-ups) to the character.
+        var consumeData = await _consumeHandler.BuildConsumeResult(db, account, new ConsumeRequestDB
+        {
+            ConsumeItemServerIdAndCounts = (request.ConsumeItemDBIdsAndCounts ?? [])
+                .ToDictionary(kv => kv.Key, kv => (long)kv.Value),
+            IsItemsValid = true,
+            IsValid = true
+        });
+
+        var favorResolver = await _parcelHandler.BuildParcel(db, account,
+            new ParcelResult(ParcelType.FavorExp, character.UniqueId, consumeData.AccumulatedExp));
+
+        response.CharacterDB = favorResolver.ParcelResult.CharacterDBs?.FirstOrDefault(x => x.ServerId == character.ServerId)
+            ?? character.ToMap(_mapper);
+        response.ConsumeStackableItemDBResult = consumeData.ParcelResult.ItemDBs?.Values.ToList() ?? [];
+        response.ParcelResultDB = favorResolver.ParcelResult;
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Character_SetFavorites)]
     public async Task<CharacterSetFavoritesResponse> SetFavorites(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CharacterHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CharacterHandler.cs
@@ -4,11 +4,13 @@ using BlueArchiveAPI.Services;
 using Schale.Data;
 using Schale.Data.GameModel;
 using Schale.Data.ModelMapping;
+using Schale.MX.GameLogic.DBModel;
 using Schale.MX.NetworkProtocol;
 using Schale.MX.GameLogic.Parcel;
 using Schale.FlatData;
 using Shittim_Server.Core;
 using Shittim_Server.Managers;
+using Shittim_Server.Services;
 
 namespace Shittim_Server.Core.NetworkProtocol.Handlers;
 
@@ -17,16 +19,22 @@ public class CharacterHandler : ProtocolHandlerBase
     private readonly ISessionKeyService _sessionService;
     private readonly CharacterManager _characterManager;
     private readonly IMapper _mapper;
+    private readonly ConsumeHandler _consumeHandler;
+    private readonly ParcelHandler _parcelHandler;
 
     public CharacterHandler(
         IProtocolHandlerRegistry registry,
         ISessionKeyService sessionService,
         CharacterManager characterManager,
-        IMapper mapper) : base(registry)
+        IMapper mapper,
+        ConsumeHandler consumeHandler,
+        ParcelHandler parcelHandler) : base(registry)
     {
         _sessionService = sessionService;
         _characterManager = characterManager;
         _mapper = mapper;
+        _consumeHandler = consumeHandler;
+        _parcelHandler = parcelHandler;
     }
 
     [ProtocolHandler(Protocol.Character_SetFavorites)]

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CharacterHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CharacterHandler.cs
@@ -107,6 +107,22 @@ public class CharacterHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Character_List)]
+    public async Task<CharacterListResponse> List(
+        SchaleDataContext db,
+        CharacterListRequest request,
+        CharacterListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.CharacterDBs = db.GetAccountCharacters(account.ServerId).ToMapList(_mapper);
+        response.TSSCharacterDBs = [];
+        response.WeaponDBs = db.GetAccountWeapons(account.ServerId).ToMapList(_mapper);
+        response.CostumeDBs = db.GetAccountCostumes(account.ServerId).ToMapList(_mapper);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Character_SetFavorites)]
     public async Task<CharacterSetFavoritesResponse> SetFavorites(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CharacterHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CharacterHandler.cs
@@ -71,6 +71,42 @@ public class CharacterHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Character_SetCostume)]
+    public async Task<CharacterSetCostumeResponse> SetCostume(
+        SchaleDataContext db,
+        CharacterSetCostumeRequest request,
+        CharacterSetCostumeResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var character = db.Characters.FirstOrDefault(x =>
+                x.AccountServerId == account.ServerId && x.UniqueId == request.CharacterUniqueId)
+            ?? throw new WebAPIException(WebAPIErrorCode.CharacterNotFound,
+                $"Character {request.CharacterUniqueId} not found");
+
+        var costumes = db.GetAccountCostumes(account.ServerId).ToList();
+
+        var current = costumes.FirstOrDefault(x => x.BoundCharacterServerId == character.ServerId);
+        if (current != null)
+        {
+            current.BoundCharacterServerId = 0;
+            response.UnsetCostumeDB = current.ToMap(_mapper);
+        }
+
+        if (request.CostumeIdToSet is long costumeId)
+        {
+            var target = costumes.FirstOrDefault(x => x.UniqueId == costumeId)
+                ?? throw new WebAPIException(WebAPIErrorCode.CharacterCostumeNotFound,
+                    $"Costume {costumeId} not owned");
+
+            target.BoundCharacterServerId = character.ServerId;
+            response.SetCostumeDB = target.ToMap(_mapper);
+        }
+
+        await db.SaveChangesAsync();
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Character_SetFavorites)]
     public async Task<CharacterSetFavoritesResponse> SetFavorites(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -654,6 +654,34 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Setting)]
+    public async Task<ClanSettingResponse> Setting(
+        SchaleDataContext db,
+        ClanSettingRequest request,
+        ClanSettingResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var state = account.GameSettings.Clan;
+
+        if (!state.HasClan || !state.IsPlayerOwned)
+            throw new WebAPIException(WebAPIErrorCode.ClanDoesNotHavePermission, "Not the president");
+
+        if (request.ChangedClanName != null)
+        {
+            ValidateClanName(request.ChangedClanName);
+            state.ClanName = request.ChangedClanName;
+        }
+        if (request.ChangedNotice != null)
+            state.Notice = request.ChangedNotice;
+        state.JoinOption = request.ClanJoinOption;
+
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        response.ClanDB = BuildClanDB(db, account);
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -588,6 +588,16 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_CancelApply)]
+    public async Task<ClanCancelApplyResponse> CancelApply(
+        SchaleDataContext db,
+        ClanCancelApplyRequest request,
+        ClanCancelApplyResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -682,6 +682,18 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_ChatLog)]
+    public async Task<ClanChatLogResponse> ChatLog(
+        SchaleDataContext db,
+        ClanChatLogRequest request,
+        ClanChatLogResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.ClanChatLog = "";
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -575,6 +575,19 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Applicant)]
+    public async Task<ClanApplicantResponse> Applicant(
+        SchaleDataContext db,
+        ClanApplicantRequest request,
+        ClanApplicantResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // Join option Free means applications never exist.
+        response.ClanMemberDBs = [];
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -598,6 +598,20 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Permit)]
+    public async Task<ClanPermitResponse> Permit(
+        SchaleDataContext db,
+        ClanPermitRequest request,
+        ClanPermitResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (!account.GameSettings.Clan.IsPlayerOwned)
+            throw new WebAPIException(WebAPIErrorCode.ClanDoesNotHavePermission, "Not the president");
+
+        throw new WebAPIException(WebAPIErrorCode.ClanTargetAccountIsNotApplicant, "No applications exist");
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -453,6 +453,27 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Quit)]
+    public async Task<ClanQuitResponse> Quit(
+        SchaleDataContext db,
+        ClanQuitRequest request,
+        ClanQuitResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var state = account.GameSettings.Clan;
+
+        if (!state.HasClan)
+            throw new WebAPIException(WebAPIErrorCode.ClanAccountAlreadyQuitClan, "Not in a clan");
+        if (state.IsPlayerOwned)
+            throw new WebAPIException(WebAPIErrorCode.ClanCanNotQuit, "The president dismisses, not quits");
+
+        state.HasClan = false;
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -530,6 +530,51 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Member)]
+    public async Task<ClanMemberResponse> Member(
+        SchaleDataContext db,
+        ClanMemberRequest request,
+        ClanMemberResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var aronaAccount = db.Accounts.FirstOrDefault(x => x.DevId == SchaleAI.AccountDevId);
+
+        AccountDBServer target;
+        if (request.MemberAccountId == account.ServerId)
+        {
+            target = account;
+            response.ClanMemberDB = BuildAccountMemberDB(db, account);
+        }
+        else if (aronaAccount != null && request.MemberAccountId == aronaAccount.ServerId)
+        {
+            target = aronaAccount;
+            response.ClanMemberDB = BuildAronaMemberDB(db, account);
+        }
+        else
+        {
+            throw new WebAPIException(WebAPIErrorCode.ClanMemberNotFound, $"Member {request.MemberAccountId} not found");
+        }
+
+        var clanDb = BuildClanDB(db, account);
+        response.ClanDB = clanDb;
+
+        var targetCharacter = db.Characters.FirstOrDefault(c => c.ServerId == target.RepresentCharacterServerId);
+        response.DetailedAccountInfoDB = new DetailedAccountInfoDB
+        {
+            AccountId = target.ServerId,
+            Nickname = target.Nickname ?? "Sensei",
+            Level = target.Level,
+            ClanName = clanDb.ClanName,
+            Comment = target.Comment ?? "",
+            FriendCount = 0,
+            RepresentCharacterUniqueId = targetCharacter?.UniqueId ?? target.RepresentCharacterServerId,
+            CharacterCount = db.GetAccountCharacters(target.ServerId).Count(),
+            AssistCharacterDBs = []
+        };
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -630,6 +630,30 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Confer)]
+    public async Task<ClanConferResponse> Confer(
+        SchaleDataContext db,
+        ClanConferRequest request,
+        ClanConferResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var aronaAccount = db.Accounts.FirstOrDefault(x => x.DevId == SchaleAI.AccountDevId);
+
+        if (!account.GameSettings.Clan.IsPlayerOwned)
+            throw new WebAPIException(WebAPIErrorCode.ClanDoesNotHavePermission, "Not the president");
+        if (aronaAccount == null || request.MemberAccountId != aronaAccount.ServerId)
+            throw new WebAPIException(WebAPIErrorCode.ClanMemberNotFound, $"Member {request.MemberAccountId} not found");
+
+        var conferred = BuildAronaMemberDB(db, account);
+        conferred.ClanSocialGrade = request.ConferingGrade;
+
+        response.ClanMemberDB = conferred;
+        response.AccountClanMemberDB = BuildAccountMemberDB(db, account);
+        response.ClanDB = BuildClanDB(db, account);
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -262,4 +262,113 @@ public class ClanHandler : ProtocolHandlerBase
 
         return response;
     }
+
+    private ClanDB BuildClanDB(SchaleDataContext db, AccountDBServer account)
+    {
+        var state = account.GameSettings.Clan;
+        var aronaAccount = db.Accounts.FirstOrDefault(x => x.DevId == SchaleAI.AccountDevId);
+        var aronaCharacter = aronaAccount != null
+            ? db.Characters.FirstOrDefault(c => c.ServerId == aronaAccount.RepresentCharacterServerId)
+            : null;
+        var accountCharacter = db.Characters.FirstOrDefault(c => c.ServerId == account.RepresentCharacterServerId);
+
+        return state.IsPlayerOwned
+            ? new ClanDB
+            {
+                ClanDBId = 777,
+                ClanName = state.ClanName ?? "Schale Network",
+                ClanChannelName = "channel_777",
+                ClanPresidentNickName = account.Nickname ?? "Sensei",
+                ClanPresidentRepresentCharacterUniqueId = accountCharacter?.UniqueId ?? account.RepresentCharacterServerId,
+                ClanNotice = state.Notice ?? "",
+                ClanJoinOption = state.JoinOption,
+                ClanMemberCount = 2
+            }
+            : new ClanDB
+            {
+                ClanDBId = 777,
+                ClanName = "Schale Network",
+                ClanChannelName = "channel_777",
+                ClanPresidentNickName = aronaAccount?.Nickname ?? "Arona",
+                ClanPresidentRepresentCharacterUniqueId = aronaCharacter?.UniqueId ?? 19900006,
+                ClanNotice = "Welcome to Schale Network\n\nEnjoy your stay, Sensei!",
+                ClanJoinOption = ClanJoinOption.Free,
+                ClanMemberCount = 2
+            };
+    }
+
+    // official's own member entry carries no AttachmentDB; other members' do.
+    private ClanMemberDB BuildAccountMemberDB(SchaleDataContext db, AccountDBServer account)
+    {
+        var accountCharacter = db.Characters.FirstOrDefault(c => c.ServerId == account.RepresentCharacterServerId);
+        return new ClanMemberDB
+        {
+            AccountId = account.ServerId,
+            AccountLevel = account.Level,
+            ClanDBId = 777,
+            RepresentCharacterUniqueId = accountCharacter?.UniqueId ?? account.RepresentCharacterServerId,
+            ClanSocialGrade = account.GameSettings.Clan.IsPlayerOwned ? ClanSocialGrade.President : ClanSocialGrade.Member,
+            AccountNickName = account.Nickname ?? "Sensei",
+            AttendanceCount = 33,
+            GameLoginDate = account.LastConnectTime,
+            LastLoginDate = account.LastConnectTime,
+            JoinDate = account.CreateDate
+        };
+    }
+
+    private ClanMemberDB BuildAronaMemberDB(SchaleDataContext db, AccountDBServer account)
+    {
+        var aronaAccount = db.Accounts.FirstOrDefault(x => x.DevId == SchaleAI.AccountDevId);
+        var aronaCharacter = aronaAccount != null
+            ? db.Characters.FirstOrDefault(c => c.ServerId == aronaAccount.RepresentCharacterServerId)
+            : null;
+        var aronaAttachment = aronaAccount != null ? db.GetAccountAttachments(aronaAccount.ServerId).FirstOrDefault() : null;
+        var aronaCafeComfort = aronaAccount != null
+            ? db.Cafes.FirstOrDefault(x => x.AccountServerId == aronaAccount.ServerId)?.ProductionDB?.ComfortValue ?? 0
+            : 0;
+
+        return new ClanMemberDB
+        {
+            AccountId = aronaAccount?.ServerId ?? 100000,
+            AccountLevel = aronaAccount?.Level ?? 90,
+            ClanDBId = 777,
+            RepresentCharacterUniqueId = aronaCharacter?.UniqueId ?? 19900006,
+            ClanSocialGrade = account.GameSettings.Clan.IsPlayerOwned ? ClanSocialGrade.Member : ClanSocialGrade.President,
+            AccountNickName = aronaAccount?.Nickname ?? "Arona",
+            CafeComfortValue = aronaCafeComfort,
+            GameLoginDate = aronaAccount?.LastConnectTime ?? DateTime.UtcNow,
+            LastLoginDate = aronaAccount?.LastConnectTime ?? DateTime.UtcNow,
+            JoinDate = aronaAccount?.CreateDate ?? DateTime.UtcNow,
+            AttachmentDB = aronaAttachment?.ToMap(_mapper) ?? new AccountAttachmentDB
+            {
+                AccountId = aronaAccount?.ServerId ?? 100000,
+                EmblemUniqueId = aronaAccount?.RepresentCharacterServerId ?? 19900006
+            }
+        };
+    }
+
+    private IrcServerConfig BuildIrcConfig() => new()
+    {
+        HostAddress = _configuration["Irc:Address"] ?? "localhost",
+        Port = int.Parse(_configuration["Irc:Port"] ?? "6667"),
+        Password = _configuration["Irc:Password"] ?? ""
+    };
+
+    private static void JoinDefaultClan(AccountDBServer account)
+    {
+        var state = account.GameSettings.Clan;
+        state.HasClan = true;
+        state.IsPlayerOwned = false;
+        state.JoinDate = account.GameSettings.ServerDateTime();
+    }
+
+    private void ValidateClanName(string? name)
+    {
+        if (string.IsNullOrWhiteSpace(name))
+            throw new WebAPIException(WebAPIErrorCode.ClanNameEmptyString, "Clan name is empty");
+
+        var maxLength = _excelService.GetTable<ConstCommonExcelT>().First().ClanNameLength;
+        if (maxLength > 0 && name.Length > maxLength)
+            throw new WebAPIException(WebAPIErrorCode.ClanNameWithInvalidLength, $"Clan name exceeds {maxLength} characters");
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -474,6 +474,30 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Dismiss)]
+    public async Task<ClanDismissResponse> Dismiss(
+        SchaleDataContext db,
+        ClanDismissRequest request,
+        ClanDismissResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var state = account.GameSettings.Clan;
+
+        if (!state.HasClan)
+            throw new WebAPIException(WebAPIErrorCode.ClanAccountAlreadyQuitClan, "Not in a clan");
+        if (!state.IsPlayerOwned)
+            throw new WebAPIException(WebAPIErrorCode.ClanCanNotDismiss, "Only the president dismisses the clan");
+
+        state.HasClan = false;
+        state.IsPlayerOwned = false;
+        state.ClanName = null;
+        state.Notice = null;
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -354,6 +354,28 @@ public class ClanHandler : ProtocolHandlerBase
         Password = _configuration["Irc:Password"] ?? ""
     };
 
+    [ProtocolHandler(Protocol.Clan_Login)]
+    public async Task<ClanLoginResponse> Login(
+        SchaleDataContext db,
+        ClanLoginRequest request,
+        ClanLoginResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (account.GameSettings.Clan.HasClan)
+        {
+            response.AccountClanDB = BuildClanDB(db, account);
+            response.AccountClanMemberDB = BuildAccountMemberDB(db, account);
+        }
+        else
+        {
+            response.AccountClanMemberDB = new ClanMemberDB { AccountId = account.ServerId };
+        }
+        response.ClanAssistSlotDBs = [];
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -430,6 +430,29 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_AutoJoin)]
+    public async Task<ClanAutoJoinResponse> AutoJoin(
+        SchaleDataContext db,
+        ClanAutoJoinRequest request,
+        ClanAutoJoinResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var state = account.GameSettings.Clan;
+
+        if (state.HasClan)
+            throw new WebAPIException(WebAPIErrorCode.ClanAccountAlreadyJoinedClan, "Already in a clan");
+
+        JoinDefaultClan(account);
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        response.IrcConfig = BuildIrcConfig();
+        response.ClanDB = BuildClanDB(db, account);
+        response.ClanMemberDB = BuildAccountMemberDB(db, account);
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -405,6 +405,31 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Join)]
+    public async Task<ClanJoinResponse> Join(
+        SchaleDataContext db,
+        ClanJoinRequest request,
+        ClanJoinResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var state = account.GameSettings.Clan;
+
+        if (state.HasClan)
+            throw new WebAPIException(WebAPIErrorCode.ClanAccountAlreadyJoinedClan, "Already in a clan");
+        if (request.ClanDBId != 777)
+            throw new WebAPIException(WebAPIErrorCode.ClanNotFound, $"Clan {request.ClanDBId} does not exist");
+
+        JoinDefaultClan(account);
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        response.IrcConfig = BuildIrcConfig();
+        response.ClanDB = BuildClanDB(db, account);
+        response.ClanMemberDB = BuildAccountMemberDB(db, account);
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -376,6 +376,35 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Create)]
+    public async Task<ClanCreateResponse> Create(
+        SchaleDataContext db,
+        ClanCreateRequest request,
+        ClanCreateResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var state = account.GameSettings.Clan;
+
+        if (state.HasClan)
+            throw new WebAPIException(WebAPIErrorCode.ClanAccountAlreadyJoinedClan, "Already in a clan");
+
+        ValidateClanName(request.ClanNickName);
+
+        state.HasClan = true;
+        state.IsPlayerOwned = true;
+        state.ClanName = request.ClanNickName;
+        state.JoinOption = request.ClanJoinOption;
+        state.JoinDate = account.GameSettings.ServerDateTime();
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        response.ClanDB = BuildClanDB(db, account);
+        response.ClanMemberDB = BuildAccountMemberDB(db, account);
+        response.AccountCurrencyDB = db.GetAccountCurrencies(account.ServerId).FirstMapTo(_mapper);
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -514,6 +514,22 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_MemberList)]
+    public async Task<ClanMemberListResponse> MemberList(
+        SchaleDataContext db,
+        ClanMemberListRequest request,
+        ClanMemberListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.ClanDB = BuildClanDB(db, account);
+        response.ClanMemberDBs = account.GameSettings.Clan.IsPlayerOwned
+            ? [BuildAccountMemberDB(db, account), BuildAronaMemberDB(db, account)]
+            : [BuildAronaMemberDB(db, account), BuildAccountMemberDB(db, account)];
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -612,6 +612,24 @@ public class ClanHandler : ProtocolHandlerBase
         throw new WebAPIException(WebAPIErrorCode.ClanTargetAccountIsNotApplicant, "No applications exist");
     }
 
+    [ProtocolHandler(Protocol.Clan_Kick)]
+    public async Task<ClanKickResponse> Kick(
+        SchaleDataContext db,
+        ClanKickRequest request,
+        ClanKickResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var aronaAccount = db.Accounts.FirstOrDefault(x => x.DevId == SchaleAI.AccountDevId);
+
+        if (!account.GameSettings.Clan.IsPlayerOwned)
+            throw new WebAPIException(WebAPIErrorCode.ClanDoesNotHavePermission, "Not the president");
+        if (aronaAccount == null || request.MemberAccountId != aronaAccount.ServerId)
+            throw new WebAPIException(WebAPIErrorCode.ClanMemberNotFound, $"Member {request.MemberAccountId} not found");
+
+        // No per-member removal state exists, so Arona is back on the next roster fetch.
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClanHandler.cs
@@ -498,6 +498,22 @@ public class ClanHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Clan_Search)]
+    public async Task<ClanSearchResponse> Search(
+        SchaleDataContext db,
+        ClanSearchRequest request,
+        ClanSearchResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // There is exactly one club; every search finds it unless the player owns it already.
+        response.ClanDBs = account.GameSettings.Clan is { HasClan: true, IsPlayerOwned: true }
+            ? []
+            : [BuildClanDB(db, account)];
+
+        return response;
+    }
+
     private static void JoinDefaultClan(AccountDBServer account)
     {
         var state = account.GameSettings.Clan;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClearDeckHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClearDeckHandler.cs
@@ -23,4 +23,66 @@ public class ClearDeckHandler : ProtocolHandlerBase
         _excelService = excelService;
     }
 
+    [ProtocolHandler(Protocol.ClearDeck_List)]
+    public async Task<ClearDeckListResponse> List(
+        SchaleDataContext db,
+        ClearDeckListRequest request,
+        ClearDeckListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // No other players to browse, so the decks come from the account's own strongest students.
+        var squadTypes = _excelService.GetTable<CharacterExcelT>()
+            .Where(x => x.IsPlayableCharacter && x.SquadType is SquadType.Main or SquadType.Support)
+            .ToDictionary(x => x.Id, x => x.SquadType);
+
+        var characters = db.GetAccountCharacters(account.ServerId).ToList()
+            .Where(c => squadTypes.ContainsKey(c.UniqueId))
+            .OrderByDescending(c => c.StarGrade)
+            .ThenByDescending(c => c.Level)
+            .ToList();
+
+        var weapons = db.GetAccountWeapons(account.ServerId).ToList()
+            .GroupBy(w => w.BoundCharacterServerId)
+            .ToDictionary(g => g.Key, g => g.First());
+
+        var strikers = new Queue<CharacterDBServer>(characters.Where(c => squadTypes[c.UniqueId] == SquadType.Main));
+        var specials = new Queue<CharacterDBServer>(characters.Where(c => squadTypes[c.UniqueId] == SquadType.Support));
+
+        var echelonType = request.ClearDeckKey.ContentType == ContentType.TimeAttackDungeon
+            ? EchelonType.TimeAttack
+            : EchelonType.Raid;
+
+        var decks = new List<ClearDeckDB>();
+        while (decks.Count < 3 && strikers.Count >= 4 && specials.Count >= 2)
+        {
+            var members = new List<CharacterDBServer>();
+            for (var i = 0; i < 4; i++) members.Add(strikers.Dequeue());
+            for (var i = 0; i < 2; i++) members.Add(specials.Dequeue());
+
+            decks.Add(new ClearDeckDB
+            {
+                LeaderUniqueId = members[0].UniqueId,
+                EchelonType = echelonType,
+                MulliganUniqueIds = [],
+                ClearDeckCharacterDBs = members.Select((c, slot) =>
+                {
+                    weapons.TryGetValue(c.ServerId, out var weapon);
+                    return new ClearDeckCharacterDB
+                    {
+                        UniqueId = c.UniqueId,
+                        StarGrade = c.StarGrade,
+                        Level = c.Level,
+                        SlotNumber = slot + 1,
+                        SquadType = squadTypes[c.UniqueId],
+                        HasWeapon = weapon != null,
+                        WeaponStarGrade = weapon?.StarGrade ?? 0
+                    };
+                }).ToList()
+            });
+        }
+
+        response.ClearDeckDBs = decks;
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ClearDeckHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ClearDeckHandler.cs
@@ -1,0 +1,26 @@
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.Data.GameModel;
+using Schale.FlatData;
+using Schale.MX.GameLogic.DBModel;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+using Shittim_Server.Services;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class ClearDeckHandler : ProtocolHandlerBase
+{
+    private readonly ISessionKeyService _sessionService;
+    private readonly ExcelTableService _excelService;
+
+    public ClearDeckHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService,
+        ExcelTableService excelService) : base(registry)
+    {
+        _sessionService = sessionService;
+        _excelService = excelService;
+    }
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -321,6 +321,50 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_UpgradeBase)]
+    public async Task<ConquestUpgradeBaseResponse> UpgradeBase(
+        SchaleDataContext db,
+        ConquestUpgradeBaseRequest request,
+        ConquestUpgradeBaseResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        var tileExcel = _conquestManager.RequireTile(info.EventContentId, request.TileUniqueId);
+        if (tileExcel.TileType != ConquestTileType.Base)
+            throw new WebAPIException(WebAPIErrorCode.ConquestInvalidTileType, $"Tile {request.TileUniqueId} is not a base");
+
+        var tile = _conquestManager.StoredTile(info, request.Difficulty, request.TileUniqueId);
+        if (tile == null || tile.TileState != TileState.FullyConquested)
+            throw new WebAPIException(WebAPIErrorCode.ConquestNotFullyConquested, $"Base {request.TileUniqueId} not conquered");
+
+        var (costType, costId, costAmount) = tile.Level switch
+        {
+            1 => (tileExcel.Upgrade2CostType, tileExcel.Upgrade2CostId, tileExcel.Upgrade2CostAmount),
+            2 => (tileExcel.Upgrade3CostType, tileExcel.Upgrade3CostId, tileExcel.Upgrade3CostAmount),
+            _ => throw new WebAPIException(WebAPIErrorCode.ConquestMaxUpgrade, $"Base {request.TileUniqueId} is max level")
+        };
+
+        var resolver = default(ParcelResolver);
+        if (costType != ParcelType.None && costAmount > 0)
+        {
+            resolver = await _parcelHandler.BuildParcel(db, account,
+                new ParcelResult(costType, costId, costAmount), isConsume: true);
+            _conquestManager.TrackConditionSpend(info, costType, costId, costAmount);
+        }
+
+        tile.Level++;
+        db.ConquestInfos.Update(info);
+        await db.SaveChangesAsync();
+
+        response.UpgradeRewards = [];
+        response.ParcelResultDB = resolver?.ParcelResult ?? new ParcelResultDB();
+        response.ConquestTileDB = tile;
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -431,6 +431,49 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_ReceiveCalculateRewards)]
+    public async Task<ConquestReceiveRewardsResponse> ReceiveCalculateRewards(
+        SchaleDataContext db,
+        ConquestReceiveRewardsRequest request,
+        ConquestReceiveRewardsResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        var conditionAmount = _conquestManager.CalculateConditionAmount(info.EventContentId);
+        if (conditionAmount <= 0
+            || info.CumulatedConditionValue - info.ReceivedCalculateRewardConditionAmount < conditionAmount)
+        {
+            throw new WebAPIException(WebAPIErrorCode.ConquestCalculateRewardNotFound, "Calculate gauge not full");
+        }
+
+        // One reward-group roll per conquered base, once per base level - the simple production model.
+        var parcels = new List<ParcelResult>();
+        var conqueredBases = info.Tiles.Where(t =>
+            t.Difficulty == request.Difficulty
+            && t.TileState == TileState.FullyConquested
+            && _excelService.GetTable<ConquestTileExcelT>()
+                .Any(x => x.Id == t.TileUniqueId && x.EventId == info.EventContentId && x.TileType == ConquestTileType.Base));
+        foreach (var baseTile in conqueredBases)
+        {
+            var tileExcel = _conquestManager.RequireTile(info.EventContentId, baseTile.TileUniqueId);
+            for (int i = 0; i < Math.Max(1, baseTile.Level); i++)
+                _conquestManager.RollRewardGroup(tileExcel.ConquestRewardId, parcels);
+        }
+
+        info.ReceivedCalculateRewardConditionAmount += conditionAmount;
+        db.ConquestInfos.Update(info);
+
+        var resolver = await _parcelHandler.BuildParcel(db, account, parcels);
+        await db.SaveChangesAsync();
+
+        response.ParcelResultDB = resolver.ParcelResult;
+        response.ConquestInfoDB = info.ToInfoDB(conditionAmount);
+        response.ConquestTileDBs = info.Tiles.Where(x => x.Difficulty == request.Difficulty).ToList();
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -502,6 +502,19 @@ public class ConquestHandler : ProtocolHandlerBase
             $"Object {request.ConquestObjectDBId} does not exist");
     }
 
+    [ProtocolHandler(Protocol.Conquest_EventObjectBattleStart)]
+    public async Task<ConquestEventObjectBattleStartResponse> EventObjectBattleStart(
+        SchaleDataContext db,
+        ConquestEventObjectBattleStartRequest request,
+        ConquestEventObjectBattleStartResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        _conquestManager.Require(db, account, request.EventContentId);
+
+        throw new WebAPIException(WebAPIErrorCode.ConquestObjectNotFound,
+            $"Object {request.ConquestObjectDBId} does not exist");
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -489,6 +489,19 @@ public class ConquestHandler : ProtocolHandlerBase
             $"Object {request.ConquestObjectDBId} does not exist");
     }
 
+    [ProtocolHandler(Protocol.Conquest_ErosionBattleResult)]
+    public async Task<ConquestErosionBattleResultResponse> ErosionBattleResult(
+        SchaleDataContext db,
+        ConquestErosionBattleResultRequest request,
+        ConquestErosionBattleResultResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        _conquestManager.Require(db, account, request.EventContentId);
+
+        throw new WebAPIException(WebAPIErrorCode.ConquestObjectNotFound,
+            $"Object {request.ConquestObjectDBId} does not exist");
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -84,6 +84,28 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_Check)]
+    public async Task<ConquestCheckResponse> Check(
+        SchaleDataContext db,
+        ConquestCheckRequest request,
+        ConquestCheckResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var info = db.GetAccountConquestInfos(account.ServerId)
+            .FirstOrDefault(x => x.EventContentId == request.EventContentId);
+        if (info == null)
+            return response;
+
+        var conditionAmount = _conquestManager.CalculateConditionAmount(info.EventContentId);
+        response.ParcelConsumeCumulatedAmount = info.CumulatedConditionValue;
+        response.CanReceiveCalculateReward = conditionAmount > 0
+            && info.CumulatedConditionValue - info.ReceivedCalculateRewardConditionAmount >= conditionAmount;
+        response.ConquestSummary = BuildSummary(info);
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -232,6 +232,38 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_MainStoryConquerWithBattleResult)]
+    public async Task<ConquestMainStoryConquerWithBattleResultResponse> MainStoryConquerWithBattleResult(
+        SchaleDataContext db,
+        ConquestMainStoryConquerWithBattleResultRequest request,
+        ConquestMainStoryConquerWithBattleResultResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        _conquestManager.RequireAndClearOpenBattle(db, info, request.Difficulty, request.TileUniqueId);
+
+        if (!ConquestManager.IsWin(request.BattleSummary))
+        {
+            response.ParcelResultDB = new ParcelResultDB();
+            response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+            response.StepAfterBattle = _conquestManager.CurrentStep(info, request.Difficulty);
+            await db.SaveChangesAsync();
+            return response;
+        }
+
+        var (tile, parcelResult, byTag) = await _conquestManager.Conquer(
+            db, account, info, request.Difficulty, request.TileUniqueId, throughBattle: true);
+
+        response.ParcelResultDB = parcelResult;
+        response.ConquestTileDB = tile;
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+        response.StepAfterBattle = _conquestManager.CurrentStep(info, request.Difficulty);
+        response.DisplayParcelByRewardTag = byTag;
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -187,6 +187,19 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_MainStoryConquerWithBattleStart)]
+    public async Task<ConquestMainStoryConquerWithBattleStartResponse> MainStoryConquerWithBattleStart(
+        SchaleDataContext db,
+        ConquestMainStoryConquerWithBattleStartRequest request,
+        ConquestMainStoryConquerWithBattleStartResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        response.ConquestStageSaveDB = StartTileBattle(db, account, info, request.Difficulty, request.TileUniqueId);
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -136,6 +136,25 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_Conquer)]
+    public async Task<ConquestConquerResponse> Conquer(
+        SchaleDataContext db,
+        ConquestConquerRequest request,
+        ConquestConquerResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        var (tile, parcelResult, _) = await _conquestManager.Conquer(
+            db, account, info, request.Difficulty, request.TileUniqueId, throughBattle: false);
+
+        response.ParcelResultDB = parcelResult;
+        response.ConquestTileDB = tile;
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -403,6 +403,34 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_NormalizeEchelon)]
+    public async Task<ConquestNormalizeEchelonResponse> NormalizeEchelon(
+        SchaleDataContext db,
+        ConquestNormalizeEchelonRequest request,
+        ConquestNormalizeEchelonResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        var stored = info.Echelons.FirstOrDefault(x =>
+                x.Difficulty == request.Difficulty && x.TileUniqueId == request.TileUniqueId)
+            ?? throw new WebAPIException(WebAPIErrorCode.ConquestEchelonNotFound,
+                $"No echelon on tile {request.TileUniqueId}");
+
+        info.Echelons.Remove(stored);
+        db.ConquestInfos.Update(info);
+        await db.SaveChangesAsync();
+
+        response.ConquestEchelonDB = new ConquestEchelonDB
+        {
+            EventContentId = stored.EventContentId,
+            Difficulty = stored.Difficulty,
+            TileUniqueId = stored.TileUniqueId
+        };
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -106,6 +106,36 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_MainStoryCheck)]
+    public async Task<ConquestMainStoryCheckResponse> MainStoryCheck(
+        SchaleDataContext db,
+        ConquestMainStoryCheckRequest request,
+        ConquestMainStoryCheckResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var info = db.GetAccountConquestInfos(account.ServerId)
+            .FirstOrDefault(x => x.EventContentId == request.EventContentId);
+        if (info == null)
+            return response;
+
+        var summary = BuildSummary(info);
+        response.ConquestMainStorySummary = new ConquestMainStorySummary
+        {
+            EventContentId = info.EventContentId,
+            Difficulty = StageDifficulty.Normal,
+            ConquestStepSummaryDict = summary.ConquestStepSummaryDict?
+                .ToDictionary(kv => kv.Key, kv => new ConquestMainStoryStepSummary
+                {
+                    ConqueredTileCount = kv.Value.ConqueredTileCount,
+                    AllTileCount = kv.Value.AllTileCount,
+                    IsStepOpen = kv.Value.IsStepOpen
+                })
+        };
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -515,6 +515,19 @@ public class ConquestHandler : ProtocolHandlerBase
             $"Object {request.ConquestObjectDBId} does not exist");
     }
 
+    [ProtocolHandler(Protocol.Conquest_EventObjectBattleResult)]
+    public async Task<ConquestEventObjectBattleResultResponse> EventObjectBattleResult(
+        SchaleDataContext db,
+        ConquestEventObjectBattleResultRequest request,
+        ConquestEventObjectBattleResultResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        _conquestManager.Require(db, account, request.EventContentId);
+
+        throw new WebAPIException(WebAPIErrorCode.ConquestObjectNotFound,
+            $"Object {request.ConquestObjectDBId} does not exist");
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -174,6 +174,19 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_ConquerWithBattleStart)]
+    public async Task<ConquestConquerWithBattleStartResponse> ConquerWithBattleStart(
+        SchaleDataContext db,
+        ConquestConquerWithBattleStartRequest request,
+        ConquestConquerWithBattleStartResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        response.ConquestStageSaveDB = StartTileBattle(db, account, info, request.Difficulty, request.TileUniqueId);
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -59,6 +59,31 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_MainStoryGetInfo)]
+    public async Task<ConquestMainStoryGetInfoResponse> MainStoryGetInfo(
+        SchaleDataContext db,
+        ConquestMainStoryGetInfoRequest request,
+        ConquestMainStoryGetInfoResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var info = _conquestManager.GetOrCreate(db, account, request.EventContentId);
+
+        response.IsFirstEnter = !info.FirstEnterDone;
+        if (!info.FirstEnterDone)
+        {
+            info.FirstEnterDone = true;
+            db.ConquestInfos.Update(info);
+            await db.SaveChangesAsync();
+        }
+
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+        response.ConquestedTileDBs = info.Tiles;
+        response.DifficultyToStepDict = info.StepByDifficulty;
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -1,0 +1,77 @@
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.Data.GameModel;
+using Schale.FlatData;
+using Schale.MX.GameLogic.DBModel;
+using Schale.MX.GameLogic.Parcel;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+using Shittim_Server.Managers;
+using Shittim_Server.Services;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class ConquestHandler : ProtocolHandlerBase
+{
+    private const int MaxManagePerRequest = 100;
+
+    private readonly ISessionKeyService _sessionService;
+    private readonly ConquestManager _conquestManager;
+    private readonly ExcelTableService _excelService;
+    private readonly ParcelHandler _parcelHandler;
+
+    public ConquestHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService,
+        ConquestManager conquestManager,
+        ExcelTableService excelService,
+        ParcelHandler parcelHandler) : base(registry)
+    {
+        _sessionService = sessionService;
+        _conquestManager = conquestManager;
+        _excelService = excelService;
+        _parcelHandler = parcelHandler;
+    }
+
+    private ConquestStageSaveDB StartTileBattle(
+        SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
+        StageDifficulty difficulty, long tileUniqueId)
+    {
+        var tileExcel = _conquestManager.RequireTile(info.EventContentId, tileUniqueId);
+
+        if (tileExcel.Step > _conquestManager.CurrentStep(info, difficulty))
+            throw new WebAPIException(WebAPIErrorCode.ConquestStepNotOpened, $"Tile {tileUniqueId} is on step {tileExcel.Step}");
+        if (_conquestManager.StoredTile(info, difficulty, tileUniqueId) != null)
+            throw new WebAPIException(WebAPIErrorCode.ConquestAlreadyConquested, $"Tile {tileUniqueId} already taken");
+        if (tileExcel.TileType != ConquestTileType.Battle)
+            throw new WebAPIException(WebAPIErrorCode.ConquestInvalidTileType, $"Tile {tileUniqueId} has no battle");
+
+        return _conquestManager.OpenTileBattle(db, account, info, difficulty, tileUniqueId, tileExcel.TileType);
+    }
+
+    private ConquestSummary BuildSummary(ConquestInfoDBServer info)
+    {
+        var tileExcels = _excelService.GetTable<ConquestTileExcelT>()
+            .Where(x => x.EventId == info.EventContentId && x.Playable)
+            .ToList();
+        var currentStep = _conquestManager.CurrentStep(info, StageDifficulty.Normal);
+        var conquered = info.Tiles
+            .Where(x => x.Difficulty == StageDifficulty.Normal)
+            .Select(x => x.TileUniqueId)
+            .ToHashSet();
+
+        return new ConquestSummary
+        {
+            EventContentId = info.EventContentId,
+            Difficulty = StageDifficulty.Normal,
+            ConquestStepSummaryDict = tileExcels
+                .GroupBy(x => x.Step)
+                .ToDictionary(g => g.Key, g => new ConquestStepSummary
+                {
+                    ConqueredTileCount = g.Count(x => conquered.Contains(x.Id)),
+                    AllTileCount = g.Count(),
+                    IsStepOpen = g.Key <= currentStep
+                })
+        };
+    }
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -200,6 +200,38 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_ConquerWithBattleResult)]
+    public async Task<ConquestConquerWithBattleResultResponse> ConquerWithBattleResult(
+        SchaleDataContext db,
+        ConquestConquerWithBattleResultRequest request,
+        ConquestConquerWithBattleResultResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        _conquestManager.RequireAndClearOpenBattle(db, info, request.Difficulty, request.TileUniqueId);
+
+        if (!ConquestManager.IsWin(request.BattleSummary))
+        {
+            response.ParcelResultDB = new ParcelResultDB();
+            response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+            response.StepAfterBattle = _conquestManager.CurrentStep(info, request.Difficulty);
+            await db.SaveChangesAsync();
+            return response;
+        }
+
+        var (tile, parcelResult, byTag) = await _conquestManager.Conquer(
+            db, account, info, request.Difficulty, request.TileUniqueId, throughBattle: true);
+
+        response.ParcelResultDB = parcelResult;
+        response.ConquestTileDB = tile;
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+        response.StepAfterBattle = _conquestManager.CurrentStep(info, request.Difficulty);
+        response.DisplayParcelByRewardTag = byTag;
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -474,6 +474,21 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    // Nothing spawns event objects in the minimal machine, so the object battles and pickups are
+    // guard-only: an id that does not exist answers ConquestObjectNotFound instead of a 500.
+    [ProtocolHandler(Protocol.Conquest_ErosionBattleStart)]
+    public async Task<ConquestErosionBattleStartResponse> ErosionBattleStart(
+        SchaleDataContext db,
+        ConquestErosionBattleStartRequest request,
+        ConquestErosionBattleStartResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        _conquestManager.Require(db, account, request.EventContentId);
+
+        throw new WebAPIException(WebAPIErrorCode.ConquestObjectNotFound,
+            $"Object {request.ConquestObjectDBId} does not exist");
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -365,6 +365,44 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_DeployEchelon)]
+    public async Task<ConquestConquerDeployEchelonResponse> DeployEchelon(
+        SchaleDataContext db,
+        ConquestConquerDeployEchelonRequest request,
+        ConquestConquerDeployEchelonResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        if (request.EchelonDB == null)
+            throw new WebAPIException(WebAPIErrorCode.ConquestEchelonNotFound, "No echelon in the request");
+
+        var existing = info.Echelons.FirstOrDefault(x =>
+            x.Difficulty == request.Difficulty && x.TileUniqueId == request.TileUniqueId);
+        if (existing == null)
+        {
+            existing = new ConquestEchelonDB
+            {
+                EventContentId = info.EventContentId,
+                Difficulty = request.Difficulty,
+                TileUniqueId = request.TileUniqueId
+            };
+            info.Echelons.Add(existing);
+        }
+
+        existing.EchelonDB = request.EchelonDB;
+        existing.AssistUseInfo = request.ClanAssistUseInfo;
+        info.EchelonChangeCount++;
+
+        db.ConquestInfos.Update(info);
+        await db.SaveChangesAsync();
+
+        response.ConquestEchelonDBs = info.Echelons;
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -33,6 +33,32 @@ public class ConquestHandler : ProtocolHandlerBase
         _parcelHandler = parcelHandler;
     }
 
+    [ProtocolHandler(Protocol.Conquest_GetInfo)]
+    public async Task<ConquestGetInfoResponse> GetInfo(
+        SchaleDataContext db,
+        ConquestGetInfoRequest request,
+        ConquestGetInfoResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var info = _conquestManager.GetOrCreate(db, account, request.EventContentId);
+
+        response.IsFirstEnter = !info.FirstEnterDone;
+        if (!info.FirstEnterDone)
+        {
+            info.FirstEnterDone = true;
+            db.ConquestInfos.Update(info);
+            await db.SaveChangesAsync();
+        }
+
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+        response.ConquestedTileDBs = info.Tiles;
+        response.ConquestEchelonDBs = info.Echelons;
+        response.DifficultyToStepDict = info.StepByDifficulty;
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -155,6 +155,25 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_MainStoryConquer)]
+    public async Task<ConquestMainStoryConquerResponse> MainStoryConquer(
+        SchaleDataContext db,
+        ConquestMainStoryConquerRequest request,
+        ConquestMainStoryConquerResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        var (tile, parcelResult, _) = await _conquestManager.Conquer(
+            db, account, info, request.Difficulty, request.TileUniqueId, throughBattle: false);
+
+        response.ParcelResultDB = parcelResult;
+        response.ConquestTileDB = tile;
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -528,6 +528,19 @@ public class ConquestHandler : ProtocolHandlerBase
             $"Object {request.ConquestObjectDBId} does not exist");
     }
 
+    [ProtocolHandler(Protocol.Conquest_TakeEventObject)]
+    public async Task<ConquestTakeEventObjectResponse> TakeEventObject(
+        SchaleDataContext db,
+        ConquestTakeEventObjectRequest request,
+        ConquestTakeEventObjectResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        _conquestManager.Require(db, account, request.EventContentId);
+
+        throw new WebAPIException(WebAPIErrorCode.ConquestObjectNotFound,
+            $"Object {request.ConquestObjectDBId} does not exist");
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ConquestHandler.cs
@@ -264,6 +264,63 @@ public class ConquestHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Conquest_ManageBase)]
+    public async Task<ConquestManageBaseResponse> ManageBase(
+        SchaleDataContext db,
+        ConquestManageBaseRequest request,
+        ConquestManageBaseResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        var info = _conquestManager.Require(db, account, request.EventContentId);
+
+        var tileExcel = _conquestManager.RequireTile(info.EventContentId, request.TileUniqueId);
+        if (tileExcel.TileType != ConquestTileType.Base)
+            throw new WebAPIException(WebAPIErrorCode.ConquestInvalidTileType, $"Tile {request.TileUniqueId} is not a base");
+
+        var tile = _conquestManager.StoredTile(info, request.Difficulty, request.TileUniqueId);
+        if (tile == null || tile.TileState != TileState.FullyConquested)
+            throw new WebAPIException(WebAPIErrorCode.ConquestNotFullyConquested, $"Base {request.TileUniqueId} not conquered");
+
+        // No excel column caps a manage batch, so the ceiling is fixed here; a free tile manages once.
+        var manageCount = Math.Clamp(request.ManageCount, 1, MaxManagePerRequest);
+        if (tileExcel.ManageCostType == ParcelType.None || tileExcel.ManageCostAmount <= 0)
+            manageCount = 1;
+
+        if (tileExcel.ManageCostType != ParcelType.None && tileExcel.ManageCostAmount > 0)
+        {
+            await _parcelHandler.BuildParcel(db, account,
+                new ParcelResult(tileExcel.ManageCostType, tileExcel.ManageCostId, (long)tileExcel.ManageCostAmount * manageCount),
+                isConsume: true);
+            _conquestManager.TrackConditionSpend(info, tileExcel.ManageCostType, tileExcel.ManageCostId,
+                (long)tileExcel.ManageCostAmount * manageCount);
+        }
+
+        var all = new List<ParcelResult>();
+        response.ClearParcels = [];
+        for (int i = 0; i < manageCount; i++)
+        {
+            var run = new List<ParcelResult>();
+            _conquestManager.RollRewardGroup(tileExcel.ConquestRewardId, run);
+            all.AddRange(run);
+            response.ClearParcels.Add(run.Select(x => new ParcelInfo
+            {
+                Key = new ParcelKeyPair { Type = x.Type, Id = x.Id },
+                Amount = x.Amount
+            }).ToList());
+        }
+
+        var resolver = await _parcelHandler.BuildParcel(db, account, all);
+        db.ConquestInfos.Update(info);
+        await db.SaveChangesAsync();
+
+        response.ConquerBonusParcels = [];
+        response.BonusParcels = [];
+        response.ParcelResultDB = resolver.ParcelResult;
+        response.ConquestInfoDB = info.ToInfoDB(_conquestManager.CalculateConditionAmount(info.EventContentId));
+
+        return response;
+    }
+
     private ConquestStageSaveDB StartTileBattle(
         SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
         StageDifficulty difficulty, long tileUniqueId)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ContentSweepHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ContentSweepHandler.cs
@@ -378,6 +378,27 @@ public class ContentSweepHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.ContentSweep_SetMultiSweepPresetName)]
+    public async Task<ContentSweepSetMultiSweepPresetNameResponse> SetMultiSweepPresetName(
+        SchaleDataContext db,
+        ContentSweepSetMultiSweepPresetNameRequest request,
+        ContentSweepSetMultiSweepPresetNameResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var preset = (account.GameSettings.MultiSweepPresetDBs ?? [])
+            .FirstOrDefault(x => x.PresetId == request.PresetId);
+        if (preset != null)
+        {
+            preset.PresetName = request.PresetName;
+            db.Accounts.Update(account);
+            await db.SaveChangesAsync();
+        }
+
+        response.MultiSweepPresetDBs = account.GameSettings.MultiSweepPresetDBs ?? [];
+        return response;
+    }
+
     private static bool GenerateProbability(long probability)
     {
         if (probability == 0) return true;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ContentSweepHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ContentSweepHandler.cs
@@ -333,6 +333,18 @@ public class ContentSweepHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.ContentSweep_MultiSweepPresetList)]
+    public async Task<ContentSweepMultiSweepPresetListResponse> MultiSweepPresetList(
+        SchaleDataContext db,
+        ContentSweepMultiSweepPresetListRequest request,
+        ContentSweepMultiSweepPresetListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.MultiSweepPresetDBs = account.GameSettings.MultiSweepPresetDBs ?? [];
+        return response;
+    }
+
     [ProtocolHandler(Protocol.ContentSweep_SetMultiSweepPreset)]
     public async Task<ContentSweepSetMultiSweepPresetResponse> SetMultiSweepPreset(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -651,6 +651,39 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             return response;
         }
 
+        [ProtocolHandler(Protocol.Craft_ShiftingReward)]
+        public async Task<CraftShiftingRewardResponse> ShiftingReward(
+            SchaleDataContext db,
+            CraftShiftingRewardRequest request,
+            CraftShiftingRewardResponse response)
+        {
+            var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+            var now = account.GameSettings.ServerDateTime();
+
+            var slot = GetShiftingSlot(db, account.ServerId, request.SlotId)
+                ?? throw new WebAPIException(WebAPIErrorCode.CraftInfoNotFound, $"Shifting slot {request.SlotId} has no craft");
+
+            if (slot.EndTime > now)
+                throw new WebAPIException(WebAPIErrorCode.CraftProcessNotComplete, $"Shifting slot {request.SlotId} is still processing");
+
+            var recipe = _excelService.GetTable<ShiftingCraftRecipeExcelT>().FirstOrDefault(x => x.Id == slot.CraftRecipeId)
+                ?? throw new WebAPIException(WebAPIErrorCode.CraftInvalidData, $"Shifting recipe {slot.CraftRecipeId} no longer exists");
+
+            var parcelResolver = await _parcelHandler.BuildParcel(db, account,
+                new ParcelResult(recipe.ResultParcel, recipe.ResultId, recipe.ResultAmount * slot.CraftAmount));
+            response.ParcelResultDB = parcelResolver.ParcelResult;
+
+            db.ShiftingCraftInfos.Remove(slot);
+            await db.SaveChangesAsync();
+
+            _missionService.UpdateMissionProgress(db, account, MissionCompleteConditionType.Reset_CraftCount);
+
+            // Read as the claimed slot echoed back; whether official lists survivors here instead is unobserved.
+            response.TargetCraftInfos = [_mapper.Map<ShiftingCraftInfoDB>(slot)];
+
+            return response;
+        }
+
         // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
         private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -462,6 +462,47 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             return response;
         }
 
+        [ProtocolHandler(Protocol.Craft_RewardAll)]
+        public async Task<CraftRewardAllResponse> RewardAll(
+            SchaleDataContext db,
+            CraftRewardAllRequest request,
+            CraftRewardAllResponse response)
+        {
+            var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+            var now = account.GameSettings.ServerDateTime();
+
+            var slots = db.CraftInfos
+                .Where(x => x.AccountServerId == account.ServerId)
+                .ToList();
+            var finished = slots.Where(x => x.StartTime != DateTime.MaxValue && x.EndTime <= now).ToList();
+
+            if (finished.Count > 0)
+            {
+                var parcels = finished
+                    .SelectMany(s => s.Nodes ?? [])
+                    .Where(x => x.CraftNodeResult?.ParcelInfo != null)
+                    .Select(x => new ParcelResult(
+                        x.CraftNodeResult!.ParcelInfo!.Key.Type,
+                        x.CraftNodeResult.ParcelInfo.Key.Id,
+                        x.CraftNodeResult.ParcelInfo.Amount))
+                    .ToList();
+
+                var parcelResolver = await _parcelHandler.BuildParcel(db, account, parcels);
+                response.ParcelResultDB = parcelResolver.ParcelResult;
+
+                db.CraftInfos.RemoveRange(finished);
+                await db.SaveChangesAsync();
+
+                _missionService.UpdateMissionProgress(
+                    db, account, MissionCompleteConditionType.Reset_CraftCount, amount: finished.Count);
+            }
+
+            var remaining = slots.Except(finished).ToList();
+            response.CraftInfos = remaining.Count > 0 ? _mapper.Map<List<CraftInfoDB>>(remaining) : null;
+
+            return response;
+        }
+
         // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
         private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -613,6 +613,44 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             return response;
         }
 
+        [ProtocolHandler(Protocol.Craft_ShiftingCompleteProcessAll)]
+        public async Task<CraftShiftingCompleteProcessAllResponse> ShiftingCompleteProcessAll(
+            SchaleDataContext db,
+            CraftShiftingCompleteProcessAllRequest request,
+            CraftShiftingCompleteProcessAllResponse response)
+        {
+            var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+            var now = account.GameSettings.ServerDateTime();
+
+            var slots = db.ShiftingCraftInfos
+                .Where(x => x.AccountServerId == account.ServerId)
+                .ToList();
+
+            var common = _excelService.GetTable<ConstCommonExcelT>().FirstOrDefault();
+            long tickets = 0;
+            foreach (var slot in slots)
+            {
+                var cost = FinishShiftingSlot(slot, now, common);
+                if (cost > 0)
+                {
+                    tickets += cost;
+                    db.ShiftingCraftInfos.Update(slot);
+                }
+            }
+
+            if (tickets > 0)
+            {
+                var resolver = await _parcelHandler.BuildParcel(db, account,
+                    new ParcelResult(ParcelType.Item, ShiftingTicketItemId(common), tickets), isConsume: true);
+                response.ParcelResultDB = resolver.ParcelResult;
+            }
+            await db.SaveChangesAsync();
+
+            response.CraftInfoDBs = slots.Count > 0 ? _mapper.Map<List<ShiftingCraftInfoDB>>(slots) : null;
+
+            return response;
+        }
+
         // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
         private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -684,6 +684,50 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             return response;
         }
 
+        [ProtocolHandler(Protocol.Craft_ShiftingRewardAll)]
+        public async Task<CraftShiftingRewardAllResponse> ShiftingRewardAll(
+            SchaleDataContext db,
+            CraftShiftingRewardAllRequest request,
+            CraftShiftingRewardAllResponse response)
+        {
+            var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+            var now = account.GameSettings.ServerDateTime();
+
+            var slots = db.ShiftingCraftInfos
+                .Where(x => x.AccountServerId == account.ServerId)
+                .ToList();
+
+            var recipes = _excelService.GetTable<ShiftingCraftRecipeExcelT>();
+            var claimed = new List<ShiftingCraftInfoDBServer>();
+            var parcels = new List<ParcelResult>();
+            foreach (var slot in slots.Where(x => x.EndTime <= now))
+            {
+                // A slot whose recipe row vanished with a table update stays behind rather than failing the whole claim.
+                var recipe = recipes.FirstOrDefault(x => x.Id == slot.CraftRecipeId);
+                if (recipe == null)
+                    continue;
+                parcels.Add(new ParcelResult(recipe.ResultParcel, recipe.ResultId, recipe.ResultAmount * slot.CraftAmount));
+                claimed.Add(slot);
+            }
+
+            if (claimed.Count > 0)
+            {
+                var parcelResolver = await _parcelHandler.BuildParcel(db, account, parcels);
+                response.ParcelResultDB = parcelResolver.ParcelResult;
+
+                db.ShiftingCraftInfos.RemoveRange(claimed);
+                await db.SaveChangesAsync();
+
+                _missionService.UpdateMissionProgress(
+                    db, account, MissionCompleteConditionType.Reset_CraftCount, amount: claimed.Count);
+            }
+
+            var remaining = slots.Except(claimed).ToList();
+            response.CraftInfoDBs = remaining.Count > 0 ? _mapper.Map<List<ShiftingCraftInfoDB>>(remaining) : null;
+
+            return response;
+        }
+
         // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
         private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -23,6 +23,8 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
         // The captured 3-tier craft ran 7h30m and its CompleteProcess burned 3 tickets, so 2.5h per selected tier with 1 ticket per started 2.5h reproduces both observations.
         private static readonly TimeSpan TierDuration = TimeSpan.FromHours(2.5);
         private const long TimeSkipTicketItemId = 2;
+        // The live game's 8 chambers: ConstCommonExcelT only carries a slot cap for the shifting track.
+        private const int CraftSlotCount = 8;
 
         private readonly ISessionKeyService _sessionService;
         private readonly ExcelTableService _excelService;
@@ -70,10 +72,14 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
                 craftInfos = craftInfos.Except(corrupted).ToList();
             }
 
-            // Official omits both keys when there is nothing to list (the first captured sample is bare Protocol + ServerTimeTicks) and never sends
-            // ShiftingCraftInfos at all.
+            // Official omits both keys when there is nothing to list (the first captured sample is bare Protocol + ServerTimeTicks;
+            // the captured account also had no shifting crafts running).
             response.CraftInfos = craftInfos.Count > 0 ? _mapper.Map<List<CraftInfoDB>>(craftInfos) : null;
-            response.ShiftingCraftInfos = null;
+
+            var shiftingInfos = db.ShiftingCraftInfos
+                .Where(x => x.AccountServerId == account.ServerId)
+                .ToList();
+            response.ShiftingCraftInfos = shiftingInfos.Count > 0 ? _mapper.Map<List<ShiftingCraftInfoDB>>(shiftingInfos) : null;
 
             return response;
         }
@@ -113,6 +119,7 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
                 var gold = System.Math.Min(request.ConsumeGoldAmount, currency.CurrencyDict[CurrencyTypes.Gold]);
                 currency.CurrencyDict[CurrencyTypes.Gold] -= gold;
                 currency.UpdateTimeDict[CurrencyTypes.Gold] = now;
+                db.Currencies.Update(currency);
             }
 
             // The node being leveled: the freshly selected (still seedless) node if there is one, otherwise the base node, created on the very first call.
@@ -187,6 +194,18 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             var slot = GetSlot(db, account.ServerId, request.SlotId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ServerFailedToHandleRequest, $"Craft slot {request.SlotId} has no craft");
 
+            ResolveNodeResults(slot, now);
+
+            db.CraftInfos.Update(slot);
+            await db.SaveChangesAsync();
+
+            response.CraftInfoDB = _mapper.Map<CraftInfoDB>(slot);
+
+            return response;
+        }
+
+        private void ResolveNodeResults(CraftInfoDBServer slot, DateTime now)
+        {
             var selectedNodes = (slot.Nodes ?? []).Where(x => x.NodeId != 0).ToList();
             if (selectedNodes.Count == 0)
                 throw new WebAPIException(WebAPIErrorCode.ServerFailedToHandleRequest, "No nodes selected to process");
@@ -239,13 +258,6 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
 
             slot.StartTime = now;
             slot.EndTime = now + TierDuration * selectedNodes.Count;
-
-            db.CraftInfos.Update(slot);
-            await db.SaveChangesAsync();
-
-            response.CraftInfoDB = _mapper.Map<CraftInfoDB>(slot);
-
-            return response;
         }
 
         [ProtocolHandler(Protocol.Craft_CompleteProcess)]
@@ -321,6 +333,32 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
 
             return response;
         }
+
+        // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
+        private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
+        {
+            if (slot.EndTime <= now)
+                return 0;
+
+            var cost = common?.ShiftingCraftTicketConsumeAmount > 0
+                ? common.ShiftingCraftTicketConsumeAmount
+                : (long)System.Math.Ceiling((slot.EndTime - now) / ShiftingDuration(common));
+            slot.EndTime = now;
+            return cost;
+        }
+
+        private static long ShiftingTicketItemId(ConstCommonExcelT? common) =>
+            common?.CraftTicketItemUniqueId > 0 ? common.CraftTicketItemUniqueId : TimeSkipTicketItemId;
+
+        private static TimeSpan ShiftingDuration(ConstCommonExcelT? common)
+        {
+            // ShiftingCraftDuration's per-index meaning is unobserved; first entry, one hour when absent.
+            var seconds = common?.ShiftingCraftDuration?.FirstOrDefault() ?? 0;
+            return TimeSpan.FromSeconds(seconds > 0 ? seconds : 3600);
+        }
+
+        private static ShiftingCraftInfoDBServer? GetShiftingSlot(SchaleDataContext db, long accountServerId, long slotId) =>
+            db.ShiftingCraftInfos.FirstOrDefault(x => x.AccountServerId == accountServerId && x.SlotSequence == slotId);
 
         private static CraftInfoDBServer? GetSlot(SchaleDataContext db, long accountServerId, long slotId) =>
             db.CraftInfos.FirstOrDefault(x => x.AccountServerId == accountServerId && x.SlotSequence == slotId);

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -423,6 +423,45 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             return response;
         }
 
+        [ProtocolHandler(Protocol.Craft_CompleteProcessAll)]
+        public async Task<CraftCompleteProcessAllResponse> CompleteProcessAll(
+            SchaleDataContext db,
+            CraftCompleteProcessAllRequest request,
+            CraftCompleteProcessAllResponse response)
+        {
+            var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+            var now = account.GameSettings.ServerDateTime();
+
+            var started = db.CraftInfos
+                .Where(x => x.AccountServerId == account.ServerId)
+                .ToList()
+                .Where(x => x.StartTime != DateTime.MaxValue)
+                .ToList();
+
+            var processing = started.Where(x => x.EndTime > now).ToList();
+            if (processing.Count > 0)
+            {
+                var ticket = db.GetAccountItems(account.ServerId).FirstOrDefault(x => x.UniqueId == TimeSkipTicketItemId);
+                foreach (var slot in processing)
+                {
+                    if (ticket != null)
+                    {
+                        var ticketsNeeded = (long)System.Math.Ceiling((slot.EndTime - now) / TierDuration);
+                        ticket.StackCount -= System.Math.Min(ticketsNeeded, ticket.StackCount);
+                    }
+                    slot.EndTime = now;
+                    db.CraftInfos.Update(slot);
+                }
+                if (ticket != null)
+                    response.TicketItemDB = ticket.ToMap(_mapper);
+                await db.SaveChangesAsync();
+            }
+
+            response.CraftInfoDBs = started.Count > 0 ? _mapper.Map<List<CraftInfoDB>>(started) : null;
+
+            return response;
+        }
+
         // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
         private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -583,6 +583,36 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             return response;
         }
 
+        [ProtocolHandler(Protocol.Craft_ShiftingCompleteProcess)]
+        public async Task<CraftShiftingCompleteProcessResponse> ShiftingCompleteProcess(
+            SchaleDataContext db,
+            CraftShiftingCompleteProcessRequest request,
+            CraftShiftingCompleteProcessResponse response)
+        {
+            var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+            var now = account.GameSettings.ServerDateTime();
+
+            var slot = GetShiftingSlot(db, account.ServerId, request.SlotId)
+                ?? throw new WebAPIException(WebAPIErrorCode.CraftInfoNotFound, $"Shifting slot {request.SlotId} has no craft");
+
+            var common = _excelService.GetTable<ConstCommonExcelT>().FirstOrDefault();
+            var tickets = FinishShiftingSlot(slot, now, common);
+            if (tickets > 0)
+            {
+                // No TicketItemDB field on this response, so the ticket burn rides in the ParcelResultDB.
+                var resolver = await _parcelHandler.BuildParcel(db, account,
+                    new ParcelResult(ParcelType.Item, ShiftingTicketItemId(common), tickets), isConsume: true);
+                response.ParcelResultDB = resolver.ParcelResult;
+            }
+
+            db.ShiftingCraftInfos.Update(slot);
+            await db.SaveChangesAsync();
+
+            response.CraftInfoDB = _mapper.Map<ShiftingCraftInfoDB>(slot);
+
+            return response;
+        }
+
         // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
         private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -334,6 +334,95 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             return response;
         }
 
+        [ProtocolHandler(Protocol.Craft_AutoBeginProcess)]
+        public async Task<CraftAutoBeginProcessResponse> AutoBeginProcess(
+            SchaleDataContext db,
+            CraftAutoBeginProcessRequest request,
+            CraftAutoBeginProcessResponse response)
+        {
+            var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+            var now = account.GameSettings.ServerDateTime();
+
+            var presetNodes = request.PresetSlotDB?.PresetNodeDBs?
+                .Where(x => x.IsActivated)
+                .OrderBy(x => x.NodeTier)
+                .ToList();
+            if (presetNodes == null || presetNodes.Count == 0)
+                throw new WebAPIException(WebAPIErrorCode.CraftInvalidPresetSlotDB, "Preset slot has no activated nodes");
+
+            var count = System.Math.Max(1, request.Count);
+
+            var used = db.CraftInfos
+                .Where(x => x.AccountServerId == account.ServerId)
+                .Select(x => x.SlotSequence)
+                .ToHashSet();
+            var freeSlots = Enumerable.Range(1, CraftSlotCount)
+                .Select(s => (long)s)
+                .Where(s => !used.Contains(s))
+                .ToList();
+            if (freeSlots.Count < count)
+                throw new WebAPIException(WebAPIErrorCode.CraftNotEnoughEmptySlotCount, $"Requested {count} crafts with {freeSlots.Count} free slots");
+
+            var consumes = new List<ConsumeRequestDB>();
+            for (long i = 0; i < count; i++)
+                consumes.AddRange(presetNodes.Where(x => x.ConsumeRequestDB != null).Select(x => x.ConsumeRequestDB!));
+            var consumeResult = await _consumeHandler.BuildConsumeResult(db, account, consumes);
+
+            var priorityNodeIds = presetNodes.Select(x => x.PriortyNodeId).Where(x => x != 0).ToHashSet();
+            var started = new List<CraftInfoDBServer>();
+            foreach (var slotSequence in freeSlots.Take((int)count))
+            {
+                var slot = new CraftInfoDBServer
+                {
+                    AccountServerId = account.ServerId,
+                    SlotSequence = slotSequence,
+                    StartTime = DateTime.MaxValue,
+                    EndTime = DateTime.MaxValue,
+                    CraftSlotOpenDate = now,
+                    Nodes = []
+                };
+
+                // The manual walk collapsed: each activated preset entry is one UpdateNodeLevel plus one SelectNode.
+                foreach (var _ in presetNodes)
+                {
+                    CraftNodeDB node;
+                    if (slot.Nodes.Count == 0)
+                    {
+                        node = new CraftNodeDB();
+                        slot.Nodes.Add(node);
+                    }
+                    else
+                        node = slot.Nodes[^1];
+
+                    node.NodeLevel += 1;
+                    node.NodeRandomSeed = Random.Shared.Next(1, int.MaxValue);
+                    node.LeafNodeIds = RollLeafNodes(node.NodeTier);
+                    if (node.LeafNodeIds.Count == 0)
+                        break;
+
+                    // Whether a preset entry's PriortyNodeId names its own tier or the next is unobserved, so any rolled leaf the preset asks for wins; first leaf otherwise.
+                    var leaf = node.LeafNodeIds.FirstOrDefault(priorityNodeIds.Contains);
+                    slot.Nodes.Add(new CraftNodeDB
+                    {
+                        NodeTier = node.NodeTier + 1,
+                        NodeId = leaf != 0 ? leaf : node.LeafNodeIds[0],
+                        LeafNodeIds = []
+                    });
+                }
+
+                ResolveNodeResults(slot, now);
+                db.CraftInfos.Add(slot);
+                started.Add(slot);
+            }
+
+            await db.SaveChangesAsync();
+
+            response.CraftInfoDBs = _mapper.Map<List<CraftInfoDB>>(started);
+            response.ParcelResultDB = consumeResult.ParcelResult;
+
+            return response;
+        }
+
         // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
         private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/CraftHandler.cs
@@ -503,6 +503,86 @@ namespace Shittim_Server.Core.NetworkProtocol.Handlers
             return response;
         }
 
+        [ProtocolHandler(Protocol.Craft_ShiftingBeginProcess)]
+        public async Task<CraftShiftingBeginProcessResponse> ShiftingBeginProcess(
+            SchaleDataContext db,
+            CraftShiftingBeginProcessRequest request,
+            CraftShiftingBeginProcessResponse response)
+        {
+            var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+            var now = account.GameSettings.ServerDateTime();
+            var common = _excelService.GetTable<ConstCommonExcelT>().FirstOrDefault();
+
+            var maxSlots = common?.ShiftingCraftSlotMaxCapacity > 0 ? common.ShiftingCraftSlotMaxCapacity : CraftSlotCount;
+            if (request.SlotId < 1 || request.SlotId > maxSlots)
+                throw new WebAPIException(WebAPIErrorCode.CraftInvalidData, $"Shifting slot {request.SlotId} out of range");
+            if (GetShiftingSlot(db, account.ServerId, request.SlotId) != null)
+                throw new WebAPIException(WebAPIErrorCode.CraftAlreadyProcessing, $"Shifting slot {request.SlotId} is already crafting");
+
+            var recipe = _excelService.GetTable<ShiftingCraftRecipeExcelT>().FirstOrDefault(x => x.Id == request.RecipeId)
+                ?? throw new WebAPIException(WebAPIErrorCode.CraftCanNotBeginProcess, $"Shifting recipe {request.RecipeId} not found");
+
+            // CraftAmount from the ingredients about to be consumed: their ShiftingCraftQuality sum over the recipe's IngredientExp.
+            // Inferred from the field names; official's exact formula is unobserved.
+            var itemExcels = _excelService.GetTable<ItemExcelT>();
+            var accountItems = db.GetAccountItems(account.ServerId).ToList();
+            long qualitySum = 0;
+            foreach (var (serverId, consumeCount) in request.ConsumeRequestDB?.ConsumeItemServerIdAndCounts ?? new Dictionary<long, long>())
+            {
+                // The declared counts drive CraftAmount, so they have to be checked against the stack before
+                // they are believed - BuildConsumeResult commits its own transaction and cannot roll this back.
+                var item = accountItems.FirstOrDefault(x => x.ServerId == serverId);
+                if (item == null || consumeCount <= 0 || consumeCount > item.StackCount)
+                    throw new WebAPIException(WebAPIErrorCode.CraftInvalidData,
+                        $"Shifting ingredient {serverId} x{consumeCount} not available");
+
+                qualitySum += (itemExcels.FirstOrDefault(x => x.Id == item.UniqueId)?.ShiftingCraftQuality ?? 0) * consumeCount;
+            }
+            var craftAmount = recipe.IngredientExp > 0 ? System.Math.Max(1, qualitySum / recipe.IngredientExp) : 1;
+
+            // Gold first, so the currency snapshot the consume result carries already reflects it.
+            var currency = db.GetAccountCurrencies(account.ServerId).FirstOrDefault();
+            if (recipe.RequireGold > 0)
+            {
+                var gold = recipe.RequireGold * craftAmount;
+                if (currency == null || currency.CurrencyDict[CurrencyTypes.Gold] < gold)
+                    throw new WebAPIException(WebAPIErrorCode.AccountCurrencyCannotAffordCost,
+                        $"Shifting craft needs {gold} gold");
+
+                currency.CurrencyDict[CurrencyTypes.Gold] -= gold;
+                currency.UpdateTimeDict[CurrencyTypes.Gold] = now;
+                db.Currencies.Update(currency);
+            }
+
+            var consumeResult = await _consumeHandler.BuildConsumeResult(
+                db, account, request.ConsumeRequestDB ?? new ConsumeRequestDB());
+
+            var costs = new List<ParcelResult>();
+            if (recipe.RequireItemId != 0 && recipe.RequireItemAmount > 0)
+                costs.Add(new ParcelResult(ParcelType.Item, recipe.RequireItemId, recipe.RequireItemAmount * craftAmount));
+            if (recipe.AdditionalCostParcelType != ParcelType.None && recipe.AdditionalCostParcelAmount > 0)
+                costs.Add(new ParcelResult(recipe.AdditionalCostParcelType, recipe.AdditionalCostParcelId, recipe.AdditionalCostParcelAmount));
+            if (costs.Count > 0)
+                await _parcelHandler.BuildParcel(db, account, costs, consumeResult.ParcelResult, isConsume: true);
+
+            var slot = new ShiftingCraftInfoDBServer
+            {
+                AccountServerId = account.ServerId,
+                SlotSequence = request.SlotId,
+                CraftRecipeId = request.RecipeId,
+                CraftAmount = craftAmount,
+                StartTime = now,
+                EndTime = now + ShiftingDuration(common)
+            };
+            db.ShiftingCraftInfos.Add(slot);
+            await db.SaveChangesAsync();
+
+            response.CraftInfoDB = _mapper.Map<ShiftingCraftInfoDB>(slot);
+            response.ParcelResultDB = consumeResult.ParcelResult;
+
+            return response;
+        }
+
         // Finishes the slot now and returns the skip-ticket cost that early completion carries; 0 when it was already done.
         private static long FinishShiftingSlot(ShiftingCraftInfoDBServer slot, DateTime now, ConstCommonExcelT? common)
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
@@ -406,4 +406,48 @@ public class EliminateRaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.EliminateRaid_Sweep)]
+    public async Task<EliminateRaidSweepResponse> Sweep(
+        SchaleDataContext db,
+        EliminateRaidSweepRequest request,
+        EliminateRaidSweepResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var sweepCount = Math.Max(1, request.SweepCount);
+        var stage = _excelService.GetTable<EliminateRaidStageExcelT>().FirstOrDefault(x => x.Id == request.UniqueId);
+        if (stage == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidExcelDataNotFound, $"Eliminate raid stage {request.UniqueId} not found");
+
+        await _parcelHandler.BuildParcel(db, account,
+            new ParcelResult(stage.RaidEnterCostType, stage.RaidEnterCostId, (long)stage.RaidEnterCostAmount * sweepCount),
+            isConsume: true);
+
+        var rewardRows = _excelService.GetTable<EliminateRaidStageRewardExcelT>()
+            .Where(x => x.GroupId == stage.RaidRewardGroupId)
+            .ToList();
+
+        var rewards = new List<List<ParcelInfo>>();
+        var allParcels = new List<ParcelResult>();
+        for (int i = 0; i < sweepCount; i++)
+        {
+            var rolled = RaidService.RollStageRewards(rewardRows);
+            rewards.Add(RaidService.ToParcelInfos(rolled));
+            allParcels.AddRange(rolled);
+        }
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, allParcels);
+
+        var lobby = await _raidManager.GetUpdatedLobby(db, account);
+        lobby.SweepPointByRaidUniqueId.TryGetValue(request.UniqueId, out var swept);
+        lobby.SweepPointByRaidUniqueId[request.UniqueId] = swept + sweepCount;
+        db.EliminateRaidLobbyInfos.Update(lobby);
+        await db.SaveChangesAsync();
+
+        response.TotalSeasonPoint = account.ContentInfo.EliminateRaidDataInfo.TotalRankingPoint;
+        response.Rewards = rewards;
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
@@ -300,4 +300,44 @@ public class EliminateRaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.EliminateRaid_RankingReward)]
+    public async Task<EliminateRaidRankingRewardResponse> RankingReward(
+        SchaleDataContext db,
+        EliminateRaidRankingRewardRequest request,
+        EliminateRaidRankingRewardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var lobby = await _raidManager.GetUpdatedLobby(db, account);
+        if (lobby.ReceivedRankingRewardId != 0)
+            throw new WebAPIException(WebAPIErrorCode.RaidSeasonAlreadyReceiveReward, "Ranking reward already received this season");
+
+        var season = _excelService.GetTable<EliminateRaidSeasonManageExcelT>()
+            .FirstOrDefault(x => x.SeasonId == account.ContentInfo.EliminateRaidDataInfo.SeasonId);
+        if (season == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidExcelDataNotFound, $"Eliminate raid season {account.ContentInfo.EliminateRaidDataInfo.SeasonId} not found");
+
+        var rows = _excelService.GetTable<EliminateRaidRankingRewardExcelT>()
+            .Where(x => x.RankingRewardGroupId == season.RankingRewardGroupId)
+            .ToList();
+        // Solo server: everyone is rank 1. Regional data may leave the base pair 0, hence the Global fallback.
+        var row = rows.FirstOrDefault(x => x.RankStart <= 1 && 1 <= x.RankEnd)
+               ?? rows.FirstOrDefault(x => x.RankStartGlobal <= 1 && 1 <= x.RankEndGlobal);
+        if (row == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidRankingNotFound, $"No rank-1 reward row in group {season.RankingRewardGroupId}");
+
+        var parcels = RaidService.ZipParcelColumns(row.RewardParcelType, row.RewardParcelUniqueId, row.RewardParcelAmount);
+        lobby.ReceivedRankingRewardId = row.Id;
+        lobby.CanReceiveRankingReward = false;
+        db.EliminateRaidLobbyInfos.Update(lobby);
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, parcels);
+        await db.SaveChangesAsync();
+
+        response.ReceivedRankingRewardId = row.Id;
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
@@ -259,4 +259,45 @@ public class EliminateRaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.EliminateRaid_SeasonReward)]
+    public async Task<EliminateRaidSeasonRewardResponse> SeasonReward(
+        SchaleDataContext db,
+        EliminateRaidSeasonRewardRequest request,
+        EliminateRaidSeasonRewardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var lobby = await _raidManager.GetUpdatedLobby(db, account);
+        var season = _excelService.GetTable<EliminateRaidSeasonManageExcelT>()
+            .FirstOrDefault(x => x.SeasonId == account.ContentInfo.EliminateRaidDataInfo.SeasonId);
+        if (season == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidExcelDataNotFound, $"Eliminate raid season {account.ContentInfo.EliminateRaidDataInfo.SeasonId} not found");
+
+        var gauge = Math.Min(account.ContentInfo.EliminateRaidDataInfo.TotalRankingPoint, season.MaxSeasonRewardGauage);
+        var claimable = RaidService.ClaimableSeasonRewardIds(
+            season.SeasonRewardId, season.StackedSeasonRewardGauge, gauge, lobby.ReceiveRewardIds);
+
+        if (claimable.Count == 0)
+        {
+            response.ReceiveRewardIds = lobby.ReceiveRewardIds;
+            return response;
+        }
+
+        var rewards = _excelService.GetTable<EliminateRaidStageSeasonRewardExcelT>()
+            .Where(x => claimable.Contains(x.SeasonRewardId))
+            .SelectMany(x => RaidService.ZipParcelColumns(x.SeasonRewardParcelType, x.SeasonRewardParcelUniqueId, x.SeasonRewardAmount))
+            .ToList();
+
+        lobby.ReceiveRewardIds.AddRange(claimable);
+        db.EliminateRaidLobbyInfos.Update(lobby);
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, rewards);
+        await db.SaveChangesAsync();
+
+        response.ReceiveRewardIds = lobby.ReceiveRewardIds;
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
@@ -227,4 +227,36 @@ public class EliminateRaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.EliminateRaid_GetBestTeam)]
+    public async Task<EliminateRaidGetBestTeamResponse> GetBestTeam(
+        SchaleDataContext db,
+        EliminateRaidGetBestTeamRequest request,
+        EliminateRaidGetBestTeamResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var lobby = await _raidManager.GetUpdatedLobby(db, account);
+        var stageExcels = _excelService.GetTable<EliminateRaidStageExcelT>();
+
+        var teamsByBossGroup = new Dictionary<string, List<RaidTeamSettingDB>>();
+        var summariesByGroup = account.RaidSummaries
+            .Where(x => x.ContentType == ContentTypeSummary.EliminateRaid &&
+                        !x.IsMock &&
+                        x.SeasonId == account.ContentInfo.EliminateRaidDataInfo.SeasonId)
+            .GroupBy(x => stageExcels.FirstOrDefault(s => s.Id == x.RaidStageId)?.RaidBossGroup)
+            .Where(g => g.Key != null);
+
+        foreach (var group in summariesByGroup)
+        {
+            var best = group.OrderByDescending(x => x.Score).First();
+            var groupIndex = Math.Max(0, lobby.OpenedBossGroups.IndexOf(group.Key!));
+            teamsByBossGroup[group.Key!] = RaidService.BuildBestTeams(
+                db, best, account.ServerId, EchelonType.EliminateRaid01 + groupIndex);
+        }
+
+        response.RaidTeamSettingDBsDict = teamsByBossGroup;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
@@ -21,18 +21,21 @@ public class EliminateRaidHandler : ProtocolHandlerBase
     private readonly ExcelTableService _excelService;
     private readonly IMapper _mapper;
     private readonly EliminateRaidManager _raidManager;
+    private readonly ParcelHandler _parcelHandler;
 
     public EliminateRaidHandler(
         IProtocolHandlerRegistry registry,
         ISessionKeyService sessionService,
         ExcelTableService excelService,
         IMapper mapper,
-        EliminateRaidManager raidManager) : base(registry)
+        EliminateRaidManager raidManager,
+        ParcelHandler parcelHandler) : base(registry)
     {
         _sessionService = sessionService;
         _excelService = excelService;
         _mapper = mapper;
         _raidManager = raidManager;
+        _parcelHandler = parcelHandler;
     }
 
     [ProtocolHandler(Protocol.EliminateRaid_Login)]
@@ -223,4 +226,5 @@ public class EliminateRaidHandler : ProtocolHandlerBase
 
         return response;
     }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EliminateRaidHandler.cs
@@ -340,4 +340,70 @@ public class EliminateRaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.EliminateRaid_LimitedReward)]
+    public async Task<EliminateRaidLimitedRewardResponse> LimitedReward(
+        SchaleDataContext db,
+        EliminateRaidLimitedRewardRequest request,
+        EliminateRaidLimitedRewardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var lobby = await _raidManager.GetUpdatedLobby(db, account);
+        var seasonId = account.ContentInfo.EliminateRaidDataInfo.SeasonId;
+        var season = _excelService.GetTable<EliminateRaidSeasonManageExcelT>().FirstOrDefault(x => x.SeasonId == seasonId);
+        if (season == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidExcelDataNotFound, $"Eliminate raid season {seasonId} not found");
+
+        var stageExcels = _excelService.GetTable<EliminateRaidStageExcelT>();
+        var clearedStageIds = db.Raids.Where(x =>
+                x.AccountServerId == account.ServerId &&
+                x.ContentType == ContentType.EliminateRaid &&
+                x.RaidState == RaidStatus.Clear &&
+                !x.IsPractice &&
+                x.SeasonId == seasonId)
+            .Select(x => x.UniqueId)
+            .ToList();
+
+        // One claim per cleared difficulty per season; official also splits these by boss group.
+        var claimable = clearedStageIds
+            .Select(id => stageExcels.FirstOrDefault(s => s.Id == id))
+            .Where(s => s != null)
+            .Select(s => s!.Difficulty switch
+            {
+                Difficulty.Normal => season.LimitedRewardIdNormal,
+                Difficulty.Hard => season.LimitedRewardIdHard,
+                Difficulty.VeryHard => season.LimitedRewardIdVeryhard,
+                Difficulty.Hardcore => season.LimitedRewardIdHardcore,
+                Difficulty.Extreme => season.LimitedRewardIdExtreme,
+                Difficulty.Insane => season.LimitedRewardIdInsane,
+                Difficulty.Torment => season.LimitedRewardIdTorment,
+                _ => 0L
+            })
+            .Where(id => id != 0 && !lobby.ReceiveLimitedRewardIds.Contains(id))
+            .Distinct()
+            .ToList();
+
+        if (claimable.Count == 0)
+        {
+            response.ReceiveRewardIds = lobby.ReceiveLimitedRewardIds;
+            return response;
+        }
+
+        var rewards = _excelService.GetTable<EliminateRaidStageLimitedRewardExcelT>()
+            .Where(x => claimable.Contains(x.LimitedRewardId))
+            .SelectMany(x => RaidService.ZipParcelColumns(x.LimitedRewardParcelType, x.LimitedRewardParcelUniqueId, x.LimitedRewardAmount))
+            .ToList();
+
+        lobby.ReceiveLimitedRewardIds.AddRange(claimable);
+        db.EliminateRaidLobbyInfos.Update(lobby);
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, rewards);
+        await db.SaveChangesAsync();
+
+        response.ReceiveRewardIds = lobby.ReceiveLimitedRewardIds;
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EquipmentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EquipmentHandler.cs
@@ -33,6 +33,24 @@ public class EquipmentHandler : ProtocolHandlerBase
         _missionService = missionService;
     }
 
+    [ProtocolHandler(Protocol.Equipment_Lock)]
+    public async Task<EquipmentItemLockResponse> Lock(
+        SchaleDataContext db,
+        EquipmentItemLockRequest request,
+        EquipmentItemLockResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var equipment = db.GetAccountEquipments(account.ServerId).FirstOrDefault(x => x.ServerId == request.TargetServerId)
+            ?? throw new WebAPIException(WebAPIErrorCode.EquipmentNotFound, $"Equipment {request.TargetServerId} not found");
+        equipment.IsLocked = request.IsLocked;
+        await db.SaveChangesAsync();
+
+        response.EquipmentDB = equipment.ToMap(_mapper);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Equipment_List)]
     public async Task<EquipmentItemListResponse> List(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EquipmentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EquipmentHandler.cs
@@ -51,6 +51,37 @@ public class EquipmentHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Equipment_Sell)]
+    public async Task<EquipmentItemSellResponse> Sell(
+        SchaleDataContext db,
+        EquipmentItemSellRequest request,
+        EquipmentItemSellResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var rows = new List<EquipmentDBServer>();
+        foreach (var id in request.TargetServerIds ?? [])
+        {
+            var equipment = db.GetAccountEquipments(account.ServerId).FirstOrDefault(x => x.ServerId == id)
+                ?? throw new WebAPIException(WebAPIErrorCode.EquipmentNotFound, $"Equipment {id} not found");
+            if (equipment.IsLocked)
+                throw new WebAPIException(WebAPIErrorCode.EquipmentLocked, $"Equipment {id} is locked");
+            if (equipment.BoundCharacterServerId != 0)
+                throw new WebAPIException(WebAPIErrorCode.EquipmentAlreadyEquiped, $"Equipment {id} is equipped");
+            rows.Add(equipment);
+        }
+
+        db.Equipments.RemoveRange(rows);
+        await db.SaveChangesAsync();
+
+        // No gold credited: a payout needs a per-item or per-rarity gold value and none ships - not in any
+        // ExcelDB table, not in the .bytes tables. The response carrying AccountCurrencyDB and nothing else
+        // says the live server had one server-side, so credit here if such a value ever surfaces. The
+        // item-to-currency GoodsExcel rows are not it: those are event-shop coin exchanges keyed by GoodsId.
+        response.AccountCurrencyDB = db.GetAccountCurrencies(account.ServerId).FirstMapTo(_mapper);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Equipment_List)]
     public async Task<EquipmentItemListResponse> List(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
@@ -144,7 +144,13 @@ public class EventContentHandler : ProtocolHandlerBase
         .ToList();
 
     private static int ShortestColumn(int? a, int? b, int? c)
-        => Math.Min(a ?? 0, Math.Min(b ?? 0, c ?? 0));
+    {
+        var counts = new[] { a ?? 0, b ?? 0, c ?? 0 };
+        if (counts.Distinct().Count() != 1)
+            throw new WebAPIException(WebAPIErrorCode.ShopInvalidCostOrReward,
+                $"Ragged parcel columns: types={counts[0]}, ids={counts[1]}, amounts={counts[2]}");
+        return counts[0];
+    }
 
     [ProtocolHandler(Protocol.EventContent_ReceiveStageTotalReward)]
     public async Task<EventContentReceiveStageTotalRewardResponse> ReceiveStageTotalReward(

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
@@ -65,7 +65,7 @@ public class EventContentHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
-        ShopHandler.ValidatePurchaseCount(request.PurchaseCount);
+        var purchaseCount = ShopHandler.NormalizePurchaseCount(request.PurchaseCount);
 
         var shopExcel = EventShop(request.EventContentId).FirstOrDefault(x => x.Id == request.ShopUniqueId)
             ?? throw new WebAPIException(WebAPIErrorCode.ShopExcelNotFound, $"Shop {request.ShopUniqueId} not found");
@@ -74,21 +74,23 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {request.GoodsUniqueId} not found");
 
         var purchaseHistory = await ShopManager.EnsurePurchasable(
-            db, account, request.ShopUniqueId, shopExcel, request.PurchaseCount);
+            db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
+        // Indexed to the shortest of the three columns: a ragged goods row threw IndexOutOfRange, which the client
+        // only sees as the generic failure popup.
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < (goodsExcel.ConsumeParcelType?.Count ?? 0); i++)
+        for (int i = 0; i < ShortestColumn(goodsExcel.ConsumeParcelType?.Count, goodsExcel.ConsumeParcelId?.Count, goodsExcel.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(
                 goodsExcel.ConsumeParcelType![i],
                 goodsExcel.ConsumeParcelId![i],
-                goodsExcel.ConsumeParcelAmount![i] * request.PurchaseCount));
+                goodsExcel.ConsumeParcelAmount![i] * purchaseCount));
 
         var rewardParcels = new List<ParcelResult>();
-        for (int i = 0; i < (goodsExcel.ParcelType?.Count ?? 0); i++)
+        for (int i = 0; i < ShortestColumn(goodsExcel.ParcelType?.Count, goodsExcel.ParcelId?.Count, goodsExcel.ParcelAmount?.Count); i++)
             rewardParcels.Add(new ParcelResult(
                 goodsExcel.ParcelType![i],
                 goodsExcel.ParcelId![i],
-                goodsExcel.ParcelAmount![i] * request.PurchaseCount));
+                goodsExcel.ParcelAmount![i] * purchaseCount));
 
         if (consumeParcels.Count > 0)
             await _parcelHandler.BuildParcel(db, account, consumeParcels, isConsume: true);
@@ -101,7 +103,7 @@ public class EventContentHandler : ProtocolHandlerBase
 
         response.AccountCurrencyDB = db.GetAccountCurrencies(account.ServerId).FirstOrDefaultMapTo(_mapper);
 
-        purchaseHistory.PurchaseCount += request.PurchaseCount;
+        purchaseHistory.PurchaseCount += purchaseCount;
 
         response.ShopProductDB = new ShopProductDB
         {
@@ -140,6 +142,9 @@ public class EventContentHandler : ProtocolHandlerBase
             SalePeriodTo = ""
         })
         .ToList();
+
+    private static int ShortestColumn(int? a, int? b, int? c)
+        => Math.Min(a ?? 0, Math.Min(b ?? 0, c ?? 0));
 
     [ProtocolHandler(Protocol.EventContent_ReceiveStageTotalReward)]
     public async Task<EventContentReceiveStageTotalRewardResponse> ReceiveStageTotalReward(

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
@@ -76,17 +76,17 @@ public class EventContentHandler : ProtocolHandlerBase
         var purchaseHistory = await ShopManager.EnsurePurchasable(
             db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
-        // Indexed to the shortest of the three columns: a ragged goods row threw IndexOutOfRange, which the client
-        // only sees as the generic failure popup.
+        // Column lengths are validated up front: a ragged goods row used to throw IndexOutOfRange mid-purchase,
+        // and truncating instead silently undercharged or dropped rewards.
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < ShortestColumn(goodsExcel.ConsumeParcelType?.Count, goodsExcel.ConsumeParcelId?.Count, goodsExcel.ConsumeParcelAmount?.Count); i++)
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(goodsExcel.ConsumeParcelType?.Count, goodsExcel.ConsumeParcelId?.Count, goodsExcel.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(
                 goodsExcel.ConsumeParcelType![i],
                 goodsExcel.ConsumeParcelId![i],
                 goodsExcel.ConsumeParcelAmount![i] * purchaseCount));
 
         var rewardParcels = new List<ParcelResult>();
-        for (int i = 0; i < ShortestColumn(goodsExcel.ParcelType?.Count, goodsExcel.ParcelId?.Count, goodsExcel.ParcelAmount?.Count); i++)
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(goodsExcel.ParcelType?.Count, goodsExcel.ParcelId?.Count, goodsExcel.ParcelAmount?.Count); i++)
             rewardParcels.Add(new ParcelResult(
                 goodsExcel.ParcelType![i],
                 goodsExcel.ParcelId![i],
@@ -142,15 +142,6 @@ public class EventContentHandler : ProtocolHandlerBase
             SalePeriodTo = ""
         })
         .ToList();
-
-    private static int ShortestColumn(int? a, int? b, int? c)
-    {
-        var counts = new[] { a ?? 0, b ?? 0, c ?? 0 };
-        if (counts.Distinct().Count() != 1)
-            throw new WebAPIException(WebAPIErrorCode.ShopInvalidCostOrReward,
-                $"Ragged parcel columns: types={counts[0]}, ids={counts[1]}, amounts={counts[2]}");
-        return counts[0];
-    }
 
     [ProtocolHandler(Protocol.EventContent_ReceiveStageTotalReward)]
     public async Task<EventContentReceiveStageTotalRewardResponse> ReceiveStageTotalReward(
@@ -332,7 +323,7 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {manage.GoodsId} not found");
 
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i] * drawCount));
 
         var shopRows = _excelService.GetTable<EventContentBoxGachaShopExcelT>()
@@ -353,7 +344,7 @@ public class EventContentHandler : ProtocolHandlerBase
                 if (goods == null)
                     continue;
 
-                for (int i = 0; i < ShortestColumn(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
+                for (int i = 0; i < ShopHandler.AlignedColumnCount(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
                 {
                     elementRewards.AddRange(ParcelInfo.CreateParcelInfo(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
                     rewardParcels.Add(new ParcelResult(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
@@ -571,7 +562,7 @@ public class EventContentHandler : ProtocolHandlerBase
             var costGoods = goodsTable.FirstOrDefault(x => x.Id == card.CostGoodsId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {card.CostGoodsId} not found");
 
-            for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
+            for (int i = 0; i < ShopHandler.AlignedColumnCount(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
                 consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i]));
 
             var rewards = new List<ParcelInfo>();
@@ -685,7 +676,7 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {drawn.CostGoodsId} not found");
 
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i]));
 
         var rewardParcels = new List<ParcelResult>();
@@ -768,10 +759,10 @@ public class EventContentHandler : ProtocolHandlerBase
             var goods = goodsTable.FirstOrDefault(x => x.Id == row.GoodsId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {row.GoodsId} not found");
 
-            for (int i = 0; i < ShortestColumn(goods.ConsumeParcelType?.Count, goods.ConsumeParcelId?.Count, goods.ConsumeParcelAmount?.Count); i++)
+            for (int i = 0; i < ShopHandler.AlignedColumnCount(goods.ConsumeParcelType?.Count, goods.ConsumeParcelId?.Count, goods.ConsumeParcelAmount?.Count); i++)
                 consumeParcels.Add(new ParcelResult(goods.ConsumeParcelType![i], goods.ConsumeParcelId![i], goods.ConsumeParcelAmount![i]));
 
-            for (int i = 0; i < ShortestColumn(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
+            for (int i = 0; i < ShopHandler.AlignedColumnCount(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
                 rewardParcels.Add(new ParcelResult(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
 
             play.RefreshShopIds.Remove(row.Id);

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentHandler.cs
@@ -326,7 +326,7 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {manage.GoodsId} not found");
 
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < (costGoods.ConsumeParcelType?.Count ?? 0); i++)
+        for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i] * drawCount));
 
         var shopRows = _excelService.GetTable<EventContentBoxGachaShopExcelT>()
@@ -347,7 +347,7 @@ public class EventContentHandler : ProtocolHandlerBase
                 if (goods == null)
                     continue;
 
-                for (int i = 0; i < (goods.ParcelType?.Count ?? 0); i++)
+                for (int i = 0; i < ShortestColumn(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
                 {
                     elementRewards.AddRange(ParcelInfo.CreateParcelInfo(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
                     rewardParcels.Add(new ParcelResult(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
@@ -565,7 +565,7 @@ public class EventContentHandler : ProtocolHandlerBase
             var costGoods = goodsTable.FirstOrDefault(x => x.Id == card.CostGoodsId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {card.CostGoodsId} not found");
 
-            for (int i = 0; i < (costGoods.ConsumeParcelType?.Count ?? 0); i++)
+            for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
                 consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i]));
 
             var rewards = new List<ParcelInfo>();
@@ -679,7 +679,7 @@ public class EventContentHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {drawn.CostGoodsId} not found");
 
         var consumeParcels = new List<ParcelResult>();
-        for (int i = 0; i < (costGoods.ConsumeParcelType?.Count ?? 0); i++)
+        for (int i = 0; i < ShortestColumn(costGoods.ConsumeParcelType?.Count, costGoods.ConsumeParcelId?.Count, costGoods.ConsumeParcelAmount?.Count); i++)
             consumeParcels.Add(new ParcelResult(costGoods.ConsumeParcelType![i], costGoods.ConsumeParcelId![i], costGoods.ConsumeParcelAmount![i]));
 
         var rewardParcels = new List<ParcelResult>();
@@ -762,10 +762,10 @@ public class EventContentHandler : ProtocolHandlerBase
             var goods = goodsTable.FirstOrDefault(x => x.Id == row.GoodsId)
                 ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {row.GoodsId} not found");
 
-            for (int i = 0; i < (goods.ConsumeParcelType?.Count ?? 0); i++)
+            for (int i = 0; i < ShortestColumn(goods.ConsumeParcelType?.Count, goods.ConsumeParcelId?.Count, goods.ConsumeParcelAmount?.Count); i++)
                 consumeParcels.Add(new ParcelResult(goods.ConsumeParcelType![i], goods.ConsumeParcelId![i], goods.ConsumeParcelAmount![i]));
 
-            for (int i = 0; i < (goods.ParcelType?.Count ?? 0); i++)
+            for (int i = 0; i < ShortestColumn(goods.ParcelType?.Count, goods.ParcelId?.Count, goods.ParcelAmount?.Count); i++)
                 rewardParcels.Add(new ParcelResult(goods.ParcelType![i], goods.ParcelId![i], goods.ParcelAmount![i]));
 
             play.RefreshShopIds.Remove(row.Id);

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentPlayHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentPlayHandler.cs
@@ -41,7 +41,8 @@ public class EventContentPlayHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {goodsId} not found");
 
         var cost = new List<ParcelResult>();
-        for (int i = 0; i < (goods.ConsumeParcelType?.Count ?? 0); i++)
+        var costCount = new[] { goods.ConsumeParcelType?.Count ?? 0, goods.ConsumeParcelId?.Count ?? 0, goods.ConsumeParcelAmount?.Count ?? 0 }.Min();
+        for (int i = 0; i < costCount; i++)
             cost.Add(new ParcelResult(goods.ConsumeParcelType![i], goods.ConsumeParcelId![i], goods.ConsumeParcelAmount![i] * multiplier));
 
         return cost;

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentPlayHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/EventContentPlayHandler.cs
@@ -41,7 +41,8 @@ public class EventContentPlayHandler : ProtocolHandlerBase
             ?? throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {goodsId} not found");
 
         var cost = new List<ParcelResult>();
-        var costCount = new[] { goods.ConsumeParcelType?.Count ?? 0, goods.ConsumeParcelId?.Count ?? 0, goods.ConsumeParcelAmount?.Count ?? 0 }.Min();
+        var costCount = ShopHandler.AlignedColumnCount(
+            goods.ConsumeParcelType?.Count, goods.ConsumeParcelId?.Count, goods.ConsumeParcelAmount?.Count);
         for (int i = 0; i < costCount; i++)
             cost.Add(new ParcelResult(goods.ConsumeParcelType![i], goods.ConsumeParcelId![i], goods.ConsumeParcelAmount![i] * multiplier));
 

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -100,6 +100,51 @@ public class FriendHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Friend_SetIdCard)]
+    public async Task<FriendSetIdCardResponse> SetIdCard(
+        SchaleDataContext db,
+        FriendSetIdCardRequest request,
+        FriendSetIdCardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (request.Comment?.Length > 100)
+            throw new WebAPIException(WebAPIErrorCode.FriendIdCardCommentLengthOverLimit, "Comment too long");
+
+        if (request.BackgroundId != 0
+            && !db.IdCardBackgrounds.Any(x => x.AccountServerId == account.ServerId && x.UniqueId == request.BackgroundId))
+        {
+            throw new WebAPIException(WebAPIErrorCode.FriendBackgroundNotOwned,
+                $"Id card background {request.BackgroundId} not owned");
+        }
+
+        account.Comment = request.Comment;
+        var represent = db.GetAccountCharacters(account.ServerId)
+            .FirstOrDefault(c => c.UniqueId == request.RepresentCharacterUniqueId);
+        if (represent != null)
+            account.RepresentCharacterServerId = represent.ServerId;
+
+        var card = account.GameSettings.FriendIdCard ?? BuildDefaultIdCard(db, account);
+        card.Comment = request.Comment;
+        card.RepresentCharacterUniqueId = request.RepresentCharacterUniqueId;
+        card.EmblemId = request.EmblemId;
+        card.SearchPermission = request.SearchPermission;
+        card.AutoAcceptFriendRequest = request.AutoAcceptFriendRequest;
+        card.ShowAccountLevel = request.ShowAccountLevel;
+        card.ShowFriendCode = request.ShowFriendCode;
+        card.ShowRaidRanking = request.ShowRaidRanking;
+        card.ShowArenaRanking = request.ShowArenaRanking;
+        card.ShowEliminateRaidRanking = request.ShowEliminateRaidRanking;
+        card.CardBackgroundId = request.BackgroundId;
+        card.Level = account.Level;
+        account.GameSettings.FriendIdCard = card;
+
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        return response;
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -179,6 +179,39 @@ public class FriendHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Friend_Search)]
+    public async Task<FriendSearchResponse> Search(
+        SchaleDataContext db,
+        FriendSearchRequest request,
+        FriendSearchResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var others = db.Accounts.Where(a => a.ServerId != account.ServerId).ToList()
+            .Where(a => !account.GameSettings.BlockedAccountIds.Contains(a.ServerId))
+            .ToList();
+
+        if (!string.IsNullOrEmpty(request.FriendCode))
+        {
+            if (request.FriendCode == AccountHandler.BuildFriendCode(account.ServerId))
+                throw new WebAPIException(WebAPIErrorCode.FriendSearchTargetIsYourself, "That is your own code");
+
+            var match = others.FirstOrDefault(a => AccountHandler.BuildFriendCode(a.ServerId) == request.FriendCode)
+                ?? throw new WebAPIException(WebAPIErrorCode.FriendInvalidFriendCode,
+                    $"No account with code {request.FriendCode}");
+
+            response.SearchResult = [BuildFriendDB(db, match, account)];
+            return response;
+        }
+
+        response.SearchResult = others
+            .Where(a => InLevelBand(a.Level, request.LevelOption))
+            .Select(a => BuildFriendDB(db, a, account))
+            .ToArray();
+
+        return response;
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -258,6 +258,34 @@ public class FriendHandler : ProtocolHandlerBase
         throw new WebAPIException(WebAPIErrorCode.FriendRequestNotFound, "No pending request");
     }
 
+    [ProtocolHandler(Protocol.Friend_Block)]
+    public async Task<FriendBlockResponse> Block(
+        SchaleDataContext db,
+        FriendBlockRequest request,
+        FriendBlockResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (request.TargetAccountId == account.ServerId)
+            throw new WebAPIException(WebAPIErrorCode.FriendBlockTargetIsYourself, "Cannot block yourself");
+        if (!db.Accounts.Any(a => a.ServerId == request.TargetAccountId))
+            throw new WebAPIException(WebAPIErrorCode.FriendUserIsNotFriend,
+                $"Account {request.TargetAccountId} does not exist");
+        if (account.GameSettings.BlockedAccountIds.Contains(request.TargetAccountId))
+            throw new WebAPIException(WebAPIErrorCode.FriendBlockTargetIsAlreadyBlocked, "Already blocked");
+
+        account.GameSettings.BlockedAccountIds.Add(request.TargetAccountId);
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        response.FriendDBs = [];
+        response.SentRequestFriendDBs = [];
+        response.ReceivedRequestFriendDBs = [];
+        response.BlockedUserDBs = BuildBlockedList(db, account);
+
+        return response;
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -212,6 +212,18 @@ public class FriendHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Friend_Remove)]
+    public async Task<FriendRemoveResponse> Remove(
+        SchaleDataContext db,
+        FriendRemoveRequest request,
+        FriendRemoveResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // The friend list is permanently empty on a single-player server, so any removal targets a non-friend.
+        throw new WebAPIException(WebAPIErrorCode.FriendUserIsNotFriend, "No friends to remove");
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -247,6 +247,17 @@ public class FriendHandler : ProtocolHandlerBase
         throw new WebAPIException(WebAPIErrorCode.FriendRequestNotFound, "No pending request");
     }
 
+    [ProtocolHandler(Protocol.Friend_CancelFriendRequest)]
+    public async Task<FriendCancelFriendRequestResponse> CancelFriendRequest(
+        SchaleDataContext db,
+        FriendCancelFriendRequestRequest request,
+        FriendCancelFriendRequestResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        throw new WebAPIException(WebAPIErrorCode.FriendRequestNotFound, "No pending request");
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -286,6 +286,26 @@ public class FriendHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Friend_Unblock)]
+    public async Task<FriendUnblockResponse> Unblock(
+        SchaleDataContext db,
+        FriendUnblockRequest request,
+        FriendUnblockResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        account.GameSettings.BlockedAccountIds.Remove(request.TargetAccountId);
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        response.FriendDBs = [];
+        response.SentRequestFriendDBs = [];
+        response.ReceivedRequestFriendDBs = [];
+        response.BlockedUserDBs = BuildBlockedList(db, account);
+
+        return response;
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -145,6 +145,40 @@ public class FriendHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Friend_GetFriendDetailedInfo)]
+    public async Task<FriendGetFriendDetailedInfoResponse> GetFriendDetailedInfo(
+        SchaleDataContext db,
+        FriendGetFriendDetailedInfoRequest request,
+        FriendGetFriendDetailedInfoResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var target = db.Accounts.FirstOrDefault(a => a.ServerId == request.FriendAccountId)
+            ?? throw new WebAPIException(WebAPIErrorCode.FriendUserIsNotFriend,
+                $"Account {request.FriendAccountId} does not exist");
+
+        if (account.GameSettings.BlockedAccountIds.Contains(target.ServerId))
+            throw new WebAPIException(WebAPIErrorCode.FriendBlockUserCannotOpenProfile,
+                "Target is blocked");
+
+        var attachment = db.GetAccountAttachments(target.ServerId).FirstOrDefault();
+        var representCharacter = db.Characters.FirstOrDefault(c => c.ServerId == target.RepresentCharacterServerId);
+
+        response.Nickname = target.Nickname ?? "Sensei";
+        response.Level = target.Level;
+        response.ClanName = "Schale Network";
+        response.Comment = target.Comment;
+        response.FriendCount = 0;
+        response.FriendCode = AccountHandler.BuildFriendCode(target.ServerId);
+        response.RepresentCharacterUniqueId = representCharacter?.UniqueId ?? target.RepresentCharacterServerId;
+        response.RepresentCharacterCostumeId = representCharacter?.UniqueId ?? target.RepresentCharacterServerId;
+        response.CharacterCount = db.GetAccountCharacters(target.ServerId).Count();
+        response.AttachmentDB = attachment != null ? _mapper.Map<AccountAttachmentDB>(attachment) : null;
+        response.AssistCharacterDBs = [];
+
+        return response;
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -224,6 +224,18 @@ public class FriendHandler : ProtocolHandlerBase
         throw new WebAPIException(WebAPIErrorCode.FriendUserIsNotFriend, "No friends to remove");
     }
 
+    [ProtocolHandler(Protocol.Friend_AcceptFriendRequest)]
+    public async Task<FriendAcceptFriendRequestResponse> AcceptFriendRequest(
+        SchaleDataContext db,
+        FriendAcceptFriendRequestRequest request,
+        FriendAcceptFriendRequestResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // Requests can never exist here - SendFriendRequest always refuses - so any accept targets nothing.
+        throw new WebAPIException(WebAPIErrorCode.FriendRequestNotFound, "No pending request");
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -44,9 +44,13 @@ public class FriendHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
+        response.FriendIdCardDB = account.GameSettings.FriendIdCard ?? BuildDefaultIdCard(db, account);
+        response.IdCardBackgroundDBs = db.IdCardBackgrounds
+            .Where(x => x.AccountServerId == account.ServerId).ToMapList(_mapper).ToArray();
         response.FriendDBs = [];
         response.SentRequestFriendDBs = [];
         response.ReceivedRequestFriendDBs = [];
+        response.BlockedUserDBs = BuildBlockedList(db, account);
 
         return response;
     }
@@ -67,27 +71,7 @@ public class FriendHandler : ProtocolHandlerBase
                 .Where(a => request.TargetAccountIds.Contains(a.ServerId))
                 .ToListAsync();
 
-            var friendDbs = new List<FriendDB>();
-
-            foreach (var targetAccount in targetAccounts)
-            {
-                var attachment = db.GetAccountAttachments(targetAccount.ServerId).FirstOrDefault();
-
-                friendDbs.Add(new FriendDB
-                {
-                    AccountId = targetAccount.ServerId,
-                    Nickname = targetAccount.Nickname ?? "Sensei",
-                    Level = targetAccount.Level,
-                    RepresentCharacterUniqueId = targetAccount.RepresentCharacterServerId,
-                    RepresentCharacterCostumeId = targetAccount.RepresentCharacterServerId,
-                    LastConnectTime = account.GameSettings.ServerDateTime(),
-                    ComfortValue = 10000,
-                    FriendCount = 0,
-                    AttachmentDB = attachment != null ? _mapper.Map<AccountAttachmentDB>(attachment) : null
-                });
-            }
-
-            response.ListResult = friendDbs.ToArray();
+            response.ListResult = targetAccounts.Select(x => BuildFriendDB(db, x, account)).ToArray();
         }
 
         return response;
@@ -112,6 +96,66 @@ public class FriendHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
+        response.FriendIdCardDB = account.GameSettings.FriendIdCard ?? BuildDefaultIdCard(db, account);
         return response;
     }
+
+    private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
+    {
+        return account.GameSettings.BlockedAccountIds
+            .Select(id => db.Accounts.FirstOrDefault(a => a.ServerId == id))
+            .Where(a => a != null)
+            .Select(a => BuildFriendDB(db, a!, account))
+            .ToArray();
+    }
+
+    private FriendDB BuildFriendDB(SchaleDataContext db, AccountDBServer target, AccountDBServer viewer)
+    {
+        var attachment = db.GetAccountAttachments(target.ServerId).FirstOrDefault();
+        // RepresentCharacterServerId is a Characters row id; the wire field wants the character's UniqueId.
+        var representUniqueId = RepresentCharacterUniqueId(db, target);
+        return new FriendDB
+        {
+            AccountId = target.ServerId,
+            Nickname = target.Nickname ?? "Sensei",
+            Level = target.Level,
+            RepresentCharacterUniqueId = representUniqueId,
+            RepresentCharacterCostumeId = representUniqueId,
+            LastConnectTime = viewer.GameSettings.ServerDateTime(),
+            ComfortValue = 10000,
+            FriendCount = 0,
+            AttachmentDB = attachment != null ? _mapper.Map<AccountAttachmentDB>(attachment) : null
+        };
+    }
+
+    internal static long RepresentCharacterUniqueId(SchaleDataContext db, AccountDBServer account)
+        => db.Characters.FirstOrDefault(c => c.ServerId == account.RepresentCharacterServerId)?.UniqueId
+            ?? account.RepresentCharacterServerId;
+
+    private static FriendIdCardDB BuildDefaultIdCard(SchaleDataContext db, AccountDBServer account) => new()
+    {
+        Level = account.Level,
+        FriendCode = AccountHandler.BuildFriendCode(account.ServerId),
+        Comment = account.Comment,
+        LastConnectTime = account.GameSettings.ServerDateTime(),
+        RepresentCharacterUniqueId = RepresentCharacterUniqueId(db, account),
+        RepresentCharacterCostumeId = RepresentCharacterUniqueId(db, account),
+        SearchPermission = true,
+        ShowAccountLevel = true,
+        ShowFriendCode = true
+    };
+
+    private static bool InLevelBand(int level, FriendSearchLevelOption option) => option switch
+    {
+        FriendSearchLevelOption.Recommend or FriendSearchLevelOption.All => true,
+        FriendSearchLevelOption.Level1To30 => level is >= 1 and <= 30,
+        FriendSearchLevelOption.Level31To40 => level is >= 31 and <= 40,
+        FriendSearchLevelOption.Level41To50 => level is >= 41 and <= 50,
+        FriendSearchLevelOption.Level51To60 => level is >= 51 and <= 60,
+        FriendSearchLevelOption.Level61To70 => level is >= 61 and <= 70,
+        FriendSearchLevelOption.Level71To80 => level is >= 71 and <= 80,
+        FriendSearchLevelOption.Level81To90 => level is >= 81 and <= 90,
+        FriendSearchLevelOption.Level91To100 => level is >= 91 and <= 100,
+        _ => true
+    };
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/FriendHandler.cs
@@ -236,6 +236,17 @@ public class FriendHandler : ProtocolHandlerBase
         throw new WebAPIException(WebAPIErrorCode.FriendRequestNotFound, "No pending request");
     }
 
+    [ProtocolHandler(Protocol.Friend_DeclineFriendRequest)]
+    public async Task<FriendDeclineFriendRequestResponse> DeclineFriendRequest(
+        SchaleDataContext db,
+        FriendDeclineFriendRequestRequest request,
+        FriendDeclineFriendRequestResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        throw new WebAPIException(WebAPIErrorCode.FriendRequestNotFound, "No pending request");
+    }
+
     private FriendDB[] BuildBlockedList(SchaleDataContext db, AccountDBServer account)
     {
         return account.GameSettings.BlockedAccountIds

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ItemHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ItemHandler.cs
@@ -44,6 +44,24 @@ public class ItemHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Item_Lock)]
+    public async Task<ItemLockResponse> Lock(
+        SchaleDataContext db,
+        ItemLockRequest request,
+        ItemLockResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var item = db.GetAccountItems(account.ServerId).FirstOrDefault(x => x.ServerId == request.TargetServerId)
+            ?? throw new WebAPIException(WebAPIErrorCode.ItemNotFound, $"Item {request.TargetServerId} not found");
+        item.IsLocked = request.IsLocked;
+        await db.SaveChangesAsync();
+
+        response.ItemDB = item.ToMap(_mapper);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Item_SelectTicket)]
     public async Task<ItemSelectTicketResponse> SelectTicket(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ItemHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ItemHandler.cs
@@ -62,6 +62,35 @@ public class ItemHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Item_Sell)]
+    public async Task<ItemSellResponse> Sell(
+        SchaleDataContext db,
+        ItemSellRequest request,
+        ItemSellResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var rows = new List<ItemDBServer>();
+        foreach (var id in request.TargetServerIds ?? [])
+        {
+            var item = db.GetAccountItems(account.ServerId).FirstOrDefault(x => x.ServerId == id)
+                ?? throw new WebAPIException(WebAPIErrorCode.ItemNotFound, $"Item {id} not found");
+            if (item.IsLocked)
+                throw new WebAPIException(WebAPIErrorCode.ItemLocked, $"Item {id} is locked");
+            rows.Add(item);
+        }
+
+        db.Items.RemoveRange(rows);
+        await db.SaveChangesAsync();
+
+        // No gold credited: a payout needs a per-item or per-rarity gold value and none ships - not in any
+        // ExcelDB table, not in the .bytes tables. The response carrying AccountCurrencyDB and nothing else
+        // says the live server had one server-side, so credit here if such a value ever surfaces. The
+        // item-to-currency GoodsExcel rows are not it: those are event-shop coin exchanges keyed by GoodsId.
+        response.AccountCurrencyDB = db.GetAccountCurrencies(account.ServerId).FirstMapTo(_mapper);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Item_SelectTicket)]
     public async Task<ItemSelectTicketResponse> SelectTicket(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
@@ -22,4 +22,16 @@ public class MemoryLobbyHandler : ProtocolHandlerBase
         _mapper = mapper;
     }
 
+    [ProtocolHandler(Protocol.MemoryLobby_List)]
+    public async Task<MemoryLobbyListResponse> List(
+        SchaleDataContext db,
+        MemoryLobbyListRequest request,
+        MemoryLobbyListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.MemoryLobbyDBs = db.GetAccountMemoryLobbies(account.ServerId).ToMapList(_mapper);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
@@ -63,4 +63,13 @@ public class MemoryLobbyHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.MemoryLobby_Interact)]
+    public async Task<MemoryLobbyInteractResponse> Interact(
+        SchaleDataContext db,
+        MemoryLobbyInteractRequest request,
+        MemoryLobbyInteractResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
@@ -1,0 +1,25 @@
+using AutoMapper;
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.Data.GameModel;
+using Schale.Data.ModelMapping;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class MemoryLobbyHandler : ProtocolHandlerBase
+{
+    private readonly ISessionKeyService _sessionService;
+    private readonly IMapper _mapper;
+
+    public MemoryLobbyHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService,
+        IMapper mapper) : base(registry)
+    {
+        _sessionService = sessionService;
+        _mapper = mapper;
+    }
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
@@ -34,4 +34,19 @@ public class MemoryLobbyHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.MemoryLobby_SetMain)]
+    public async Task<MemoryLobbySetMainResponse> SetMain(
+        SchaleDataContext db,
+        MemoryLobbySetMainRequest request,
+        MemoryLobbySetMainResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        account.MemoryLobbyUniqueId = request.MemoryLobbyId;
+        await db.SaveChangesAsync();
+
+        response.AccountDB = account.ToMap(_mapper);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MemoryLobbyHandler.cs
@@ -49,4 +49,18 @@ public class MemoryLobbyHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.MemoryLobby_UpdateLobbyMode)]
+    public async Task<MemoryLobbyUpdateLobbyModeResponse> UpdateLobbyMode(
+        SchaleDataContext db,
+        MemoryLobbyUpdateLobbyModeRequest request,
+        MemoryLobbyUpdateLobbyModeResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        account.LobbyMode = request.IsMemoryLobbyMode ? 1 : 0;
+        await db.SaveChangesAsync();
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
@@ -153,8 +153,12 @@ public class MomoTalkHandler : ProtocolHandlerBase
         // A FavorRankUp-gated group only opens once the student's relationship rank reaches the condition value; advancing past it regardless hands every story out at rank 1.
         if (nextGroupId > 0)
         {
+            // Ordered by Id, not table order: the condition sits on the group's opening row and only the dump
+            // happens to store them in that order.
             var nextGroupEntry = _academyMessengers
-                .FirstOrDefault(x => x.MessageGroupId == nextGroupId);
+                .Where(x => x.MessageGroupId == nextGroupId)
+                .OrderBy(x => x.Id)
+                .FirstOrDefault();
             if (nextGroupEntry != null
                 && nextGroupEntry.MessageCondition == AcademyMessageConditions.FavorRankUp
                 && favorRank < nextGroupEntry.ConditionValue)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
@@ -81,17 +81,27 @@ public class MomoTalkHandler : ProtocolHandlerBase
             var character = db.Characters.FirstOrDefault(c => c.ServerId == request.CharacterDBId && c.AccountServerId == account.ServerId);
             if (character == null) return response;
 
+            // LastReadMessageGroupId is 0 the first time a student is opened, and storing that leaves them with a
+            // conversation that can never start, so fall back to their first unlocked group.
+            var openingGroup = request.LastReadMessageGroupId > 0
+                ? request.LastReadMessageGroupId
+                : MomoTalkService.OpeningGroup(_academyMessengers, character.UniqueId, character.FavorRank);
+
             momotalkOutline = new MomoTalkOutLineDBServer
             {
                 AccountServerId = account.ServerId,
                 CharacterDBId = request.CharacterDBId,
                 CharacterId = character.UniqueId,
-                LatestMessageGroupId = request.LastReadMessageGroupId,
+                LatestMessageGroupId = openingGroup,
                 LastUpdateDate = account.GameSettings.ServerDateTime()
             };
             db.MomoTalkOutLines.Add(momotalkOutline);
             // Not saved here - the SaveChanges at the end of the handler bundles it.
         }
+
+        var favorRank = db.Characters
+            .FirstOrDefault(c => c.AccountServerId == account.ServerId
+                && c.ServerId == momotalkOutline.CharacterDBId)?.FavorRank ?? 1;
 
         long nextGroupId = 0;
         
@@ -146,13 +156,10 @@ public class MomoTalkHandler : ProtocolHandlerBase
             var nextGroupEntry = _academyMessengers
                 .FirstOrDefault(x => x.MessageGroupId == nextGroupId);
             if (nextGroupEntry != null
-                && nextGroupEntry.MessageCondition == AcademyMessageConditions.FavorRankUp)
+                && nextGroupEntry.MessageCondition == AcademyMessageConditions.FavorRankUp
+                && favorRank < nextGroupEntry.ConditionValue)
             {
-                var favorRank = db.Characters
-                    .FirstOrDefault(c => c.AccountServerId == account.ServerId
-                        && c.ServerId == momotalkOutline.CharacterDBId)?.FavorRank ?? 1;
-                if (favorRank < nextGroupEntry.ConditionValue)
-                    nextGroupId = 0;
+                nextGroupId = 0;
             }
         }
 
@@ -188,6 +195,9 @@ public class MomoTalkHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
+        MomoTalkService.SyncOutlines(db, account, _academyMessengers);
+        await db.SaveChangesAsync();
+
         var outlines = db.GetAccountMomoTalkOutLines(account.ServerId).ToList();
 
         response.MomoTalkOutLineDBs = _mapper.Map<List<MomoTalkOutLineDB>>(outlines);
@@ -208,23 +218,28 @@ public class MomoTalkHandler : ProtocolHandlerBase
         response.FavorScheduleRecords = MomoTalkService.GetAllFavorSchedules(outlines);
         response.ParcelResultDB = new();
 
-        var schedule = _academyFavorSchedules.GetScheduleById(request.ScheduleId);
-        if (schedule == null)
-            return response;
+        // Every one of these used to return an empty success, which the client reads as "reward accepted" while
+        // nothing was granted and nothing was spent. They are real refusals and have to reach the client as errors.
+        var schedule = _academyFavorSchedules.GetScheduleById(request.ScheduleId)
+            ?? throw new WebAPIException(WebAPIErrorCode.AcademyScheduleTableNotFound,
+                $"Favor schedule {request.ScheduleId} not found");
 
-        var targetOutline = outlines.FirstOrDefault(x => x.CharacterId == schedule.CharacterId);
-        if (targetOutline == null)
-            return response;
+        var targetOutline = outlines.FirstOrDefault(x => x.CharacterId == schedule.CharacterId)
+            ?? throw new WebAPIException(WebAPIErrorCode.AcademyRewardCharacterNotFound,
+                $"No MomoTalk outline for character {schedule.CharacterId}");
 
         if (targetOutline.ScheduleIds.Contains(request.ScheduleId))
-            return response;
+            throw new WebAPIException(WebAPIErrorCode.AcademyAlreadyAttendedFavorSchedule,
+                $"Favor schedule {request.ScheduleId} already attended");
 
         var accountCurrency = db.Currencies.FirstOrDefault(x => x.AccountServerId == account.ServerId);
-        if (accountCurrency == null)
-            return response;
-
-        if (!accountCurrency.CurrencyDict.TryGetValue(CurrencyTypes.AcademyTicket, out var currentTicket) || currentTicket <= 0)
-            return response;
+        if (accountCurrency == null
+            || !accountCurrency.CurrencyDict.TryGetValue(CurrencyTypes.AcademyTicket, out var currentTicket)
+            || currentTicket <= 0)
+        {
+            throw new WebAPIException(WebAPIErrorCode.AcademyTicketZero,
+                "No AcademyTicket available for a favor schedule");
+        }
 
         var parcelResults = new List<ParcelResult>
         {

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MomoTalkHandler.cs
@@ -87,6 +87,11 @@ public class MomoTalkHandler : ProtocolHandlerBase
                 ? request.LastReadMessageGroupId
                 : MomoTalkService.OpeningGroup(_academyMessengers, character.UniqueId, character.FavorRank);
 
+            // A 0 here means the student has no messenger rows or their first group is still rank-locked;
+            // persisting it would recreate the stuck-conversation state this outline exists to avoid.
+            if (openingGroup == 0)
+                return response;
+
             momotalkOutline = new MomoTalkOutLineDBServer
             {
                 AccountServerId = account.ServerId,
@@ -163,6 +168,9 @@ public class MomoTalkHandler : ProtocolHandlerBase
                 && nextGroupEntry.MessageCondition == AcademyMessageConditions.FavorRankUp
                 && favorRank < nextGroupEntry.ConditionValue)
             {
+                // Remember where the conversation stopped so the login sync can resume it once the rank
+                // is reached - without this marker it cannot tell a gate-stop from an unread group.
+                momotalkOutline.PendingGateGroupId = nextGroupId;
                 nextGroupId = 0;
             }
         }
@@ -170,6 +178,7 @@ public class MomoTalkHandler : ProtocolHandlerBase
         if (nextGroupId > 0)
         {
             momotalkOutline.LatestMessageGroupId = nextGroupId;
+            momotalkOutline.PendingGateGroupId = null;
             momotalkOutline.LastUpdateDate = account.GameSettings.ServerDateTime();
             // Keep current outline choice null to prevent duplicate message bubbles.
             // Choice history is already represented by MomoTalkChoiceDBs.

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/MultiFloorRaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/MultiFloorRaidHandler.cs
@@ -45,6 +45,17 @@ public class MultiFloorRaidHandler : ProtocolHandlerBase
         return account.GameSettings.ServerDateTime();
     }
 
+    [ProtocolHandler(Protocol.MultiFloorRaid_Login)]
+    public async Task<MultiFloorRaidLoginResponse> Login(
+        SchaleDataContext db,
+        MultiFloorRaidLoginRequest request,
+        MultiFloorRaidLoginResponse response)
+    {
+        // Official answer is just {"Protocol":49004}; the login sync carries the same empty child.
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+        return response;
+    }
+
     [ProtocolHandler(Protocol.MultiFloorRaid_Sync)]
     public async Task<MultiFloorRaidSyncResponse> Sync(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/NotificationHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/NotificationHandler.cs
@@ -25,6 +25,20 @@ public class NotificationHandler : ProtocolHandlerBase
         _mailManager = mailManager;
     }
 
+    [ProtocolHandler(Protocol.Notification_LobbyCheck)]
+    public async Task<NotificationLobbyCheckResponse> LobbyCheck(
+        SchaleDataContext db,
+        NotificationLobbyCheckRequest request,
+        NotificationLobbyCheckResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.UnreadMailCount = await _mailManager.GetUnreadMailCount(account);
+        response.EventRewardIncreaseDBs = [];
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Notification_EventContentReddotCheck)]
     public async Task<NotificationEventContentReddotResponse> EventContentReddotCheck(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/NotificationHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/NotificationHandler.cs
@@ -4,6 +4,7 @@ using Schale.Excel;
 using Schale.FlatData;
 using Schale.MX.NetworkProtocol;
 using Shittim_Server.Core;
+using Shittim_Server.Services;
 
 namespace Shittim_Server.Core.NetworkProtocol.Handlers;
 
@@ -11,14 +12,17 @@ public class NotificationHandler : ProtocolHandlerBase
 {
     private readonly ISessionKeyService _sessionService;
     private readonly ExcelTableService _excelService;
+    private readonly MailManager _mailManager;
 
     public NotificationHandler(
         IProtocolHandlerRegistry registry,
         ISessionKeyService sessionService,
-        ExcelTableService excelService) : base(registry)
+        ExcelTableService excelService,
+        MailManager mailManager) : base(registry)
     {
         _sessionService = sessionService;
         _excelService = excelService;
+        _mailManager = mailManager;
     }
 
     [ProtocolHandler(Protocol.Notification_EventContentReddotCheck)]

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/OpenConditionHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/OpenConditionHandler.cs
@@ -25,6 +25,21 @@ public class OpenConditionHandler : ProtocolHandlerBase
         _mapper = mapper;
     }
 
+    [ProtocolHandler(Protocol.OpenCondition_List)]
+    public async Task<OpenConditionListResponse> List(
+        SchaleDataContext db,
+        OpenConditionListRequest request,
+        OpenConditionListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.ConditionContents = account.GameSettings.OpenConditions
+            .Select(x => x.ContentType)
+            .ToList();
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.OpenCondition_EventList)]
     public async Task<OpenConditionEventListResponse> EventList(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/OpenConditionHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/OpenConditionHandler.cs
@@ -40,6 +40,28 @@ public class OpenConditionHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.OpenCondition_Set)]
+    public async Task<OpenConditionSetResponse> Set(
+        SchaleDataContext db,
+        OpenConditionSetRequest request,
+        OpenConditionSetResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (request.ConditionDB != null)
+        {
+            var conditions = account.GameSettings.OpenConditions;
+            conditions.RemoveAll(x => x.ContentType == request.ConditionDB.ContentType);
+            conditions.Add(request.ConditionDB);
+
+            db.Accounts.Update(account);
+            await db.SaveChangesAsync();
+        }
+
+        response.ConditionDBs = account.GameSettings.OpenConditions;
+        return response;
+    }
+
     [ProtocolHandler(Protocol.OpenCondition_EventList)]
     public async Task<OpenConditionEventListResponse> EventList(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -265,4 +265,21 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_Search)]
+    public async Task<RaidSearchResponse> Search(
+        SchaleDataContext db,
+        RaidSearchRequest request,
+        RaidSearchResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var raid = _raidManager.GetRaidData(db, account);
+        if (raid == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidSearchNotFound, "No raid in progress to search");
+
+        response.RaidDBs = [raid.ToMap(_mapper)];
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -535,4 +535,60 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_Sweep)]
+    public async Task<RaidSweepResponse> Sweep(
+        SchaleDataContext db,
+        RaidSweepRequest request,
+        RaidSweepResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (request.SweepCount < 1)
+            throw new WebAPIException(WebAPIErrorCode.RaidRewardDataNotFound, "SweepCount must be positive");
+
+        var sweepCount = Math.Min(request.SweepCount, MaxSweepPerRequest);
+        var stage = _excelService.GetTable<RaidStageExcelT>().FirstOrDefault(x => x.Id == request.UniqueId);
+        if (stage == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidExcelDataNotFound, $"Raid stage {request.UniqueId} not found");
+
+        // A sweep replays a stage the account has already beaten; without this it mints the drop table of any
+        // stage, at any difficulty, for free.
+        var cleared = db.Raids
+            .Where(x => x.AccountServerId == account.ServerId
+                && x.UniqueId == request.UniqueId
+                && x.ContentType == ContentType.Raid
+                && !x.IsPractice)
+            .ToList()
+            .Any(RaidService.IsCleared);
+        if (!cleared)
+            throw new WebAPIException(WebAPIErrorCode.RaidRewardDataNotFound, $"Raid stage {request.UniqueId} was never cleared");
+
+        var rewardRows = _excelService.GetTable<RaidStageRewardExcelT>()
+            .Where(x => x.GroupId == stage.RaidRewardGroupId)
+            .ToList();
+
+        var rewards = new List<List<ParcelInfo>>();
+        var allParcels = new List<ParcelResult>();
+        for (long i = 0; i < sweepCount; i++)
+        {
+            var rolled = RaidService.RollStageRewards(rewardRows);
+            rewards.Add(RaidService.ToParcelInfos(rolled));
+            allParcels.AddRange(rolled);
+        }
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, allParcels);
+
+        var lobby = await _raidManager.GetUpdatedLobby(db, account);
+        lobby.SweepPointByRaidUniqueId.TryGetValue(request.UniqueId, out var swept);
+        lobby.SweepPointByRaidUniqueId[request.UniqueId] = swept + sweepCount;
+        db.SingleRaidLobbyInfos.Update(lobby);
+        await db.SaveChangesAsync();
+
+        response.TotalSeasonPoint = account.ContentInfo.RaidDataInfo.TotalRankingPoint;
+        response.Rewards = rewards;
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -347,4 +347,31 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_BattleUpdate)]
+    public async Task<RaidBattleUpdateResponse> BattleUpdate(
+        SchaleDataContext db,
+        RaidBattleUpdateRequest request,
+        RaidBattleUpdateResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var raid = _raidManager.GetRaidData(db, account);
+        var battle = _raidManager.GetRaidBattleData(db, account);
+        if (raid == null || battle == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidBattleNotFound, "No raid battle in progress");
+        if (request.RaidBossIndex < 0 || request.RaidBossIndex >= raid.RaidBossDBs.Count)
+            throw new WebAPIException(WebAPIErrorCode.RaidBattleUpdateFail, $"Boss index {request.RaidBossIndex} out of range");
+
+        // Snapshot only; EndBattle's SaveBattle stays authoritative for raid.RaidBossDBs.
+        battle.RaidBossIndex = request.RaidBossIndex;
+        battle.CurrentBossHP = Math.Max(0, raid.RaidBossDBs[request.RaidBossIndex].BossCurrentHP - request.CumulativeDamage);
+        battle.CurrentBossGroggy = request.CumulativeGroggyPoint;
+        db.RaidBattles.Update(battle);
+        await db.SaveChangesAsync();
+
+        response.RaidBattleDB = battle.ToMap(_mapper);
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -495,4 +495,44 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_RankingReward)]
+    public async Task<RaidRankingRewardResponse> RankingReward(
+        SchaleDataContext db,
+        RaidRankingRewardRequest request,
+        RaidRankingRewardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var lobby = await _raidManager.GetUpdatedLobby(db, account);
+        if (lobby.ReceivedRankingRewardId != 0)
+            throw new WebAPIException(WebAPIErrorCode.RaidSeasonAlreadyReceiveReward, "Ranking reward already received this season");
+
+        var season = _excelService.GetTable<RaidSeasonManageExcelT>()
+            .FirstOrDefault(x => x.SeasonId == account.ContentInfo.RaidDataInfo.SeasonId);
+        if (season == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidExcelDataNotFound, $"Raid season {account.ContentInfo.RaidDataInfo.SeasonId} not found");
+
+        var rows = _excelService.GetTable<RaidRankingRewardExcelT>()
+            .Where(x => x.RankingRewardGroupId == season.RankingRewardGroupId)
+            .ToList();
+        // Solo server: everyone is rank 1. Regional data may leave the base pair 0, hence the Global fallback.
+        var row = rows.FirstOrDefault(x => x.RankStart <= 1 && 1 <= x.RankEnd)
+               ?? rows.FirstOrDefault(x => x.RankStartGlobal <= 1 && 1 <= x.RankEndGlobal);
+        if (row == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidRankingNotFound, $"No rank-1 reward row in group {season.RankingRewardGroupId}");
+
+        var parcels = RaidService.ZipParcelColumns(row.RewardParcelType, row.RewardParcelUniqueId, row.RewardParcelAmount);
+        lobby.ReceivedRankingRewardId = row.Id;
+        lobby.CanReceiveRankingReward = false;
+        db.SingleRaidLobbyInfos.Update(lobby);
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, parcels);
+        await db.SaveChangesAsync();
+
+        response.ReceivedRankingRewardId = row.Id;
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -248,4 +248,21 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_List)]
+    public async Task<RaidListResponse> List(
+        SchaleDataContext db,
+        RaidListRequest request,
+        RaidListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var raid = _raidManager.GetRaidData(db, account);
+
+        response.CreateRaidDBs = [];
+        response.EnterRaidDBs = raid != null ? [raid.ToMap(_mapper)] : [];
+        response.ListRaidDBs = [];
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -282,4 +282,23 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_Share)]
+    public async Task<RaidShareResponse> Share(
+        SchaleDataContext db,
+        RaidShareRequest request,
+        RaidShareResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var raid = db.Raids.FirstOrDefault(x =>
+            x.ServerId == request.RaidServerId &&
+            x.AccountServerId == account.ServerId);
+        if (raid == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidShareNotFound, $"Raid {request.RaidServerId} not found");
+
+        response.RaidDB = raid.ToMap(_mapper);
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -415,4 +415,43 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_RewardAll)]
+    public async Task<RaidRewardAllResponse> RewardAll(
+        SchaleDataContext db,
+        RaidRewardAllRequest request,
+        RaidRewardAllResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var raids = db.Raids.Where(x =>
+            x.AccountServerId == account.ServerId &&
+            x.ContentType == ContentType.Raid &&
+            !x.IsPractice &&
+            !x.IsRewardReceived &&
+            (x.RaidState == RaidStatus.Clear || x.RaidState == RaidStatus.Close)).ToList()
+            .Where(RaidService.IsCleared).ToList();
+
+        var stageExcels = _excelService.GetTable<RaidStageExcelT>();
+        var rewardExcels = _excelService.GetTable<RaidStageRewardExcelT>();
+
+        var allRewards = new List<ParcelResult>();
+        foreach (var raid in raids)
+        {
+            var stage = stageExcels.FirstOrDefault(x => x.Id == raid.UniqueId);
+            if (stage == null) continue;
+
+            allRewards.AddRange(RaidService.RollStageRewards(
+                rewardExcels.Where(x => x.GroupId == stage.RaidRewardGroupId)));
+            raid.IsRewardReceived = true;
+            db.Raids.Update(raid);
+        }
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, allRewards);
+        await db.SaveChangesAsync();
+
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -21,19 +21,25 @@ public class RaidHandler : ProtocolHandlerBase
     private readonly ExcelTableService _excelService;
     private readonly IMapper _mapper;
     private readonly RaidManager _raidManager;
+    private readonly ParcelHandler _parcelHandler;
 
     public RaidHandler(
         IProtocolHandlerRegistry registry,
         ISessionKeyService sessionService,
         ExcelTableService excelService,
         IMapper mapper,
-        RaidManager raidManager) : base(registry)
+        RaidManager raidManager,
+        ParcelHandler parcelHandler) : base(registry)
     {
         _sessionService = sessionService;
         _excelService = excelService;
         _mapper = mapper;
         _raidManager = raidManager;
+        _parcelHandler = parcelHandler;
     }
+
+    // No excel column caps a sweep; the ceiling only has to stop a crafted count from looping unboundedly.
+    private const long MaxSweepPerRequest = 100;
 
     [ProtocolHandler(Protocol.Raid_Login)]
     public async Task<RaidLoginResponse> Login(
@@ -225,4 +231,5 @@ public class RaidHandler : ProtocolHandlerBase
 
         return response;
     }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -454,4 +454,45 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_SeasonReward)]
+    public async Task<RaidSeasonRewardResponse> SeasonReward(
+        SchaleDataContext db,
+        RaidSeasonRewardRequest request,
+        RaidSeasonRewardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var lobby = await _raidManager.GetUpdatedLobby(db, account);
+        var season = _excelService.GetTable<RaidSeasonManageExcelT>()
+            .FirstOrDefault(x => x.SeasonId == account.ContentInfo.RaidDataInfo.SeasonId);
+        if (season == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidExcelDataNotFound, $"Raid season {account.ContentInfo.RaidDataInfo.SeasonId} not found");
+
+        var gauge = Math.Min(account.ContentInfo.RaidDataInfo.TotalRankingPoint, season.MaxSeasonRewardGauage);
+        var claimable = RaidService.ClaimableSeasonRewardIds(
+            season.SeasonRewardId, season.StackedSeasonRewardGauge, gauge, lobby.ReceiveRewardIds);
+
+        if (claimable.Count == 0)
+        {
+            response.ReceiveRewardIds = lobby.ReceiveRewardIds;
+            return response;
+        }
+
+        var rewards = _excelService.GetTable<RaidStageSeasonRewardExcelT>()
+            .Where(x => claimable.Contains(x.SeasonRewardId))
+            .SelectMany(x => RaidService.ZipParcelColumns(x.SeasonRewardParcelType, x.SeasonRewardParcelUniqueId, x.SeasonRewardAmount))
+            .ToList();
+
+        lobby.ReceiveRewardIds.AddRange(claimable);
+        db.SingleRaidLobbyInfos.Update(lobby);
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, rewards);
+        await db.SaveChangesAsync();
+
+        response.ReceiveRewardIds = lobby.ReceiveRewardIds;
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -52,6 +52,22 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_CompleteList)]
+    public async Task<RaidCompleteListResponse> CompleteList(
+        SchaleDataContext db,
+        RaidCompleteListRequest request,
+        RaidCompleteListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.RaidDBs = db.GetAccountRaids(account.ServerId).ToMapList(_mapper);
+        response.StackedDamage = 0;
+        response.ReceiveRewardId = [];
+        response.CurSeasonUniqueId = account.ContentInfo.RaidDataInfo.SeasonId;
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Raid_Lobby)]
     public async Task<RaidLobbyResponse> Lobby(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -374,4 +374,45 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_Reward)]
+    public async Task<RaidRewardResponse> Reward(
+        SchaleDataContext db,
+        RaidRewardRequest request,
+        RaidRewardResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var raid = db.Raids.FirstOrDefault(x =>
+            x.ServerId == request.RaidServerId &&
+            x.AccountServerId == account.ServerId &&
+            x.ContentType == ContentType.Raid);
+        if (raid == null || raid.IsPractice || request.IsPractice)
+            throw new WebAPIException(WebAPIErrorCode.RaidRewardDataNotFound, $"No rewardable raid {request.RaidServerId}");
+        if (raid.IsRewardReceived)
+            throw new WebAPIException(WebAPIErrorCode.RaidEndRewardFlagError, $"Raid {request.RaidServerId} reward already received");
+        // The dead-boss check rather than RaidState: a raid row exists from the moment a battle is created,
+        // and give-ups leave it rewardable if only the state is trusted.
+        if (!RaidService.IsCleared(raid))
+            throw new WebAPIException(WebAPIErrorCode.RaidRewardDataNotFound, $"Raid {request.RaidServerId} was not cleared");
+
+        var stage = _excelService.GetTable<RaidStageExcelT>().FirstOrDefault(x => x.Id == raid.UniqueId);
+        if (stage == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidExcelDataNotFound, $"Raid stage {raid.UniqueId} not found");
+
+        var rewards = RaidService.RollStageRewards(
+            _excelService.GetTable<RaidStageRewardExcelT>().Where(x => x.GroupId == stage.RaidRewardGroupId));
+
+        raid.IsRewardReceived = true;
+        db.Raids.Update(raid);
+
+        var parcelResult = await _parcelHandler.BuildParcel(db, account, rewards);
+        await db.SaveChangesAsync();
+
+        response.RankingPoint = account.ContentInfo.RaidDataInfo.TotalRankingPoint;
+        response.BestRankingPoint = account.ContentInfo.RaidDataInfo.BestRankingPoint;
+        response.ParcelResultDB = parcelResult.ParcelResult;
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -301,4 +301,50 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_Detail)]
+    public async Task<RaidDetailResponse> Detail(
+        SchaleDataContext db,
+        RaidDetailRequest request,
+        RaidDetailResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var raid = db.Raids.FirstOrDefault(x =>
+            x.ServerId == request.RaidServerId &&
+            x.AccountServerId == account.ServerId);
+        if (raid == null)
+            throw new WebAPIException(WebAPIErrorCode.RaidDBDataNotFound, $"Raid {request.RaidServerId} not found");
+
+        var contentType = raid.ContentType;
+        var battle = db.RaidBattles.FirstOrDefault(x =>
+            x.AccountServerId == account.ServerId &&
+            x.ContentType == contentType &&
+            x.RaidUniqueId == raid.UniqueId);
+        var damage = battle?.RaidMembers.FirstOrDefault()?.DamageCollection?.Sum(x => x.GivenDamage) ?? 0;
+
+        response.RaidDetailDB = new RaidDetailDB
+        {
+            RaidUniqueId = raid.UniqueId,
+            EndDate = raid.End,
+            DamageTable =
+            [
+                new RaidPlayerInfoDB
+                {
+                    RaidServerId = raid.ServerId,
+                    AccountId = account.ServerId,
+                    JoinDate = raid.Begin,
+                    DamageAmount = damage,
+                    RaidPlayCount = 1,
+                    Nickname = account.Nickname,
+                    CharacterId = account.RepresentCharacterServerId,
+                    AccountLevel = account.Level
+                }
+            ]
+        };
+        response.ParticipateCharacterServerIds =
+            raid.ParticipateCharacterServerIds.TryGetValue(account.ServerId, out var characterIds) ? characterIds : [];
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RaidHandler.cs
@@ -591,4 +591,25 @@ public class RaidHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Raid_GetBestTeam)]
+    public async Task<RaidGetBestTeamResponse> GetBestTeam(
+        SchaleDataContext db,
+        RaidGetBestTeamRequest request,
+        RaidGetBestTeamResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var best = account.RaidSummaries
+            .Where(x => x.ContentType == ContentTypeSummary.Raid &&
+                        !x.IsMock &&
+                        x.SeasonId == account.ContentInfo.RaidDataInfo.SeasonId)
+            .OrderByDescending(x => x.Score)
+            .FirstOrDefault();
+
+        response.RaidTeamSettingDBs = best == null
+            ? []
+            : RaidService.BuildBestTeams(db, best, account.ServerId, EchelonType.Raid);
+
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RecipeHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RecipeHandler.cs
@@ -25,4 +25,53 @@ public class RecipeHandler : ProtocolHandlerBase
         _parcelHandler = parcelHandler;
     }
 
+    [ProtocolHandler(Protocol.Recipe_Craft)]
+    public async Task<RecipeCraftResponse> Craft(
+        SchaleDataContext db,
+        RecipeCraftRequest request,
+        RecipeCraftResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var craft = _excelService.GetTable<RecipeCraftExcelT>().FirstOrDefault(x => x.Id == request.RecipeCraftUniqueId)
+            ?? throw new WebAPIException(WebAPIErrorCode.RecipeCraftNoData,
+                $"Recipe craft {request.RecipeCraftUniqueId} not found");
+
+        var ingredient = _excelService.GetTable<RecipeIngredientExcelT>()
+                .FirstOrDefault(x => x.Id == craft.RecipeIngredientId)
+            ?? throw new WebAPIException(WebAPIErrorCode.RecipeCraftDataError,
+                $"Recipe ingredient {craft.RecipeIngredientId} not found");
+
+        if (request.RecipeIngredientUniqueId != 0 && request.RecipeIngredientUniqueId != ingredient.Id)
+            throw new WebAPIException(WebAPIErrorCode.RecipeCraftDataError,
+                $"Ingredient {request.RecipeIngredientUniqueId} does not belong to craft {craft.Id}");
+
+        var costs = new List<ParcelResult>();
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(
+                 ingredient.CostParcelType?.Count, ingredient.CostId?.Count, ingredient.CostAmount?.Count); i++)
+            costs.Add(new ParcelResult(ingredient.CostParcelType![i], ingredient.CostId![i], ingredient.CostAmount![i]));
+        for (int i = 0; i < ShopHandler.AlignedColumnCount(
+                 ingredient.IngredientParcelType?.Count, ingredient.IngredientId?.Count, ingredient.IngredientAmount?.Count); i++)
+            costs.Add(new ParcelResult(ingredient.IngredientParcelType![i], ingredient.IngredientId![i], ingredient.IngredientAmount![i]));
+
+        if (costs.Count > 0)
+            await _parcelHandler.BuildParcel(db, account, costs, isConsume: true);
+
+        var rewards = new List<ParcelResult>();
+        var rewardCount = ShopHandler.AlignedColumnCount(craft.ParcelType?.Count, craft.ParcelId?.Count, craft.ResultAmountMin?.Count);
+        if (craft.ResultAmountMax?.Count != rewardCount)
+            throw new WebAPIException(WebAPIErrorCode.RecipeCraftDataError,
+                $"Ragged result columns on recipe craft {craft.Id}");
+        for (int i = 0; i < rewardCount; i++)
+        {
+            var amount = Random.Shared.NextInt64(craft.ResultAmountMin![i], craft.ResultAmountMax[i] + 1);
+            if (amount > 0)
+                rewards.Add(new ParcelResult(craft.ParcelType![i], craft.ParcelId![i], amount));
+        }
+
+        var resolver = await _parcelHandler.BuildParcel(db, account, rewards);
+        response.ParcelResultDB = resolver.ParcelResult;
+
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/RecipeHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/RecipeHandler.cs
@@ -1,0 +1,28 @@
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.FlatData;
+using Schale.MX.GameLogic.Parcel;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+using Shittim_Server.Services;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class RecipeHandler : ProtocolHandlerBase
+{
+    private readonly ISessionKeyService _sessionService;
+    private readonly ExcelTableService _excelService;
+    private readonly ParcelHandler _parcelHandler;
+
+    public RecipeHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService,
+        ExcelTableService excelService,
+        ParcelHandler parcelHandler) : base(registry)
+    {
+        _sessionService = sessionService;
+        _excelService = excelService;
+        _parcelHandler = parcelHandler;
+    }
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ResetableContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ResetableContentHandler.cs
@@ -1,0 +1,20 @@
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+using Shittim_Server.Services;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class ResetableContentHandler : ProtocolHandlerBase
+{
+    private readonly ISessionKeyService _sessionService;
+
+    public ResetableContentHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService) : base(registry)
+    {
+        _sessionService = sessionService;
+    }
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ResetableContentHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ResetableContentHandler.cs
@@ -17,4 +17,19 @@ public class ResetableContentHandler : ProtocolHandlerBase
         _sessionService = sessionService;
     }
 
+    [ProtocolHandler(Protocol.ResetableContent_Get)]
+    public async Task<ResetableContentGetResponse> Get(
+        SchaleDataContext db,
+        ResetableContentGetRequest request,
+        ResetableContentGetResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.ResetableContentValueDBs = ResetableContentService.LiveValues(
+            account, ResetableContentService.ResetWindow);
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioHandler.cs
@@ -44,6 +44,21 @@ public class ScenarioHandler : ProtocolHandlerBase
         return response;
     }
 
+    // Entering a story episode. The response model carries nothing - the client plays the scenario from its own
+    // data and reports back through Scenario_GroupHistoryUpdate and Scenario_Clear - but the protocol still has to
+    // be answered: unregistered, the gateway replies ServerFailedToHandleRequest and the client drops to the title
+    // screen with "Server failed to process request", which is what final-story episodes did.
+    [ProtocolHandler(Protocol.Scenario_Enter)]
+    public async Task<ScenarioEnterResponse> Enter(
+        SchaleDataContext db,
+        ScenarioEnterRequest request,
+        ScenarioEnterResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.Scenario_Skip)]
     public async Task<ScenarioSkipResponse> Skip(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -150,4 +150,22 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_EnterTactic)]
+    public async Task<ScenarioEnterTacticResponse> EnterTactic(
+        SchaleDataContext db,
+        ScenarioEnterTacticRequest request,
+        ScenarioEnterTacticResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        await _concentrateCampaignManager.EnterTactic(db, account, new CampaignEnterTacticRequest
+        {
+            StageUniqueId = request.StageUniqueId,
+            EchelonIndex = request.EchelonIndex,
+            EnemyIndex = request.EnemyIndex
+        });
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -108,4 +108,29 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_MapMove)]
+    public async Task<ScenarioMapMoveResponse> MapMove(
+        SchaleDataContext db,
+        ScenarioMapMoveRequest request,
+        ScenarioMapMoveResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var (stageSave, preMove) = await _concentrateCampaignManager.MoveTarget(db, account, new CampaignMapMoveRequest
+        {
+            StageUniqueId = request.StageUniqueId,
+            EchelonEntityId = request.EchelonEntityId,
+            DestPosition = request.DestPosition
+        });
+
+        response.EchelonEntityId = request.EchelonEntityId;
+        // Rewind before shaping: the response reports the mover where it stood at the start of this step,
+        // and the DisplayInfos entry is what walks it to the destination.
+        response.SaveDataDB = (StoryStrategyStageSaveDB)ConcentrateCampaignManager.ShapeForWire(
+            ConcentrateCampaignManager.RewindMovedEchelonForWire(
+                _mapper.Map<StoryStrategyStageSaveDB>(stageSave), request.EchelonEntityId, preMove));
+
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -247,4 +247,17 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_SkipMainStage)]
+    public async Task<ScenarioSkipMainStageResponse> SkipMainStage(
+        SchaleDataContext db,
+        ScenarioSkipMainStageRequest request,
+        ScenarioSkipMainStageResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // Close the run so a half-open save cannot haunt ContentSave_Get after the skip.
+        await _concentrateCampaignManager.CloseConcentrateCampaigns(db, account, request.StageUniqueId);
+
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -189,4 +189,25 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_Retreat)]
+    public async Task<ScenarioRetreatResponse> Retreat(
+        SchaleDataContext db,
+        ScenarioRetreatRequest request,
+        ScenarioRetreatResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var save = await _concentrateCampaignManager.GetConcentrateCampaign(db, account, request.StageUniqueId);
+        response.ReleasedEchelonNumbers = save?.EchelonInfos?.Keys.ToList() ?? [];
+
+        await _concentrateCampaignManager.CloseConcentrateCampaigns(db, account, request.StageUniqueId);
+
+        // Story stages cost nothing to enter, so there is nothing to refund.
+        response.ParcelResultDB = new()
+        {
+            AccountCurrencyDB = db.Currencies.Where(x => x.AccountServerId == account.ServerId).FirstOrDefault()?.ToMap(_mapper) ?? new()
+        };
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -133,4 +133,21 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_EndTurn)]
+    public async Task<ScenarioEndTurnResponse> EndTurn(
+        SchaleDataContext db,
+        ScenarioEndTurnRequest request,
+        ScenarioEndTurnResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var stageSave = await _concentrateCampaignManager.EndTurn(db, account, new CampaignEndTurnRequest
+        {
+            StageUniqueId = request.StageUniqueId
+        });
+
+        response.SaveDataDB = Wire(stageSave);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -35,4 +35,18 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
     private StoryStrategyStageSaveDB Wire(CampaignMainStageSaveDBServer save)
         => (StoryStrategyStageSaveDB)ConcentrateCampaignManager.ShapeForWire(_mapper.Map<StoryStrategyStageSaveDB>(save));
 
+    [ProtocolHandler(Protocol.Scenario_EnterMainStage)]
+    public async Task<ScenarioEnterMainStageResponse> EnterMainStage(
+        SchaleDataContext db,
+        ScenarioEnterMainStageRequest request,
+        ScenarioEnterMainStageResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var stageSave = await _concentrateCampaignManager.CreateStoryStrategyStage(db, account, request.StageUniqueId);
+
+        response.SaveDataDB = Wire(stageSave);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -210,4 +210,22 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_Portal)]
+    public async Task<ScenarioPortalResponse> Portal(
+        SchaleDataContext db,
+        ScenarioPortalRequest request,
+        ScenarioPortalResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var stageSave = await _eventContentCampaignManager.Portal(db, account, new EventContentPortalRequest
+        {
+            StageUniqueId = request.StageUniqueId,
+            EchelonEntityId = request.EchelonEntityId
+        });
+
+        response.StoryStrategyStageSaveDB = Wire(stageSave);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -49,4 +49,26 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_ConfirmMainStage)]
+    public async Task<ScenarioConfirmMainStageResponse> ConfirmMainStage(
+        SchaleDataContext db,
+        ScenarioConfirmMainStageRequest request,
+        ScenarioConfirmMainStageResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var stageSave = await _concentrateCampaignManager.StartConcentrateCampaign(db, account, new CampaignConfirmMainStageRequest
+        {
+            StageUniqueId = request.StageUniqueId
+        });
+
+        response.ParcelResultDB = new()
+        {
+            AccountDB = account.ToMap(_mapper),
+            AccountCurrencyDB = db.Currencies.Where(x => x.AccountServerId == account.ServerId).FirstOrDefault()?.ToMap(_mapper) ?? new()
+        };
+        response.SaveDataDB = Wire(stageSave);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -71,4 +71,22 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_DeployEchelon)]
+    public async Task<ScenarioDeployEchelonResponse> DeployEchelon(
+        SchaleDataContext db,
+        ScenarioDeployEchelonRequest request,
+        ScenarioDeployEchelonResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var stageSave = await _concentrateCampaignManager.DeployEchelon(db, account, new CampaignDeployEchelonRequest
+        {
+            StageUniqueId = request.StageUniqueId,
+            DeployedEchelons = request.DeployedEchelons
+        });
+
+        response.SaveDataDB = Wire(stageSave);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -1,0 +1,38 @@
+using AutoMapper;
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.Data.ModelMapping;
+using Schale.MX.GameLogic.DBModel;
+using Schale.MX.NetworkProtocol;
+using Schale.Data.GameModel;
+using Shittim_Server.Core;
+using Shittim_Server.Services;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+// StoryStrategyStageSaveDB is an empty subclass of CampaignMainStageSaveDB and these stages play on the
+// same hex maps, so every operation is handed to ConcentrateCampaignManager against a Campaign*Request.
+public class ScenarioMainStageHandler : ProtocolHandlerBase
+{
+    private readonly ISessionKeyService _sessionService;
+    private readonly ConcentrateCampaignManager _concentrateCampaignManager;
+    private readonly EventContentCampaignManager _eventContentCampaignManager;
+    private readonly IMapper _mapper;
+
+    public ScenarioMainStageHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService,
+        ConcentrateCampaignManager concentrateCampaignManager,
+        EventContentCampaignManager eventContentCampaignManager,
+        IMapper mapper) : base(registry)
+    {
+        _sessionService = sessionService;
+        _concentrateCampaignManager = concentrateCampaignManager;
+        _eventContentCampaignManager = eventContentCampaignManager;
+        _mapper = mapper;
+    }
+
+    private StoryStrategyStageSaveDB Wire(CampaignMainStageSaveDBServer save)
+        => (StoryStrategyStageSaveDB)ConcentrateCampaignManager.ShapeForWire(_mapper.Map<StoryStrategyStageSaveDB>(save));
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -228,4 +228,23 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_RestartMainStage)]
+    public async Task<ScenarioRestartMainStageResponse> RestartMainStage(
+        SchaleDataContext db,
+        ScenarioRestartMainStageRequest request,
+        ScenarioRestartMainStageResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // Creation closes whatever run was open, so a restart is just a fresh save in BeforeStart.
+        var stageSave = await _concentrateCampaignManager.CreateStoryStrategyStage(db, account, request.StageUniqueId);
+
+        response.ParcelResultDB = new()
+        {
+            AccountCurrencyDB = db.Currencies.Where(x => x.AccountServerId == account.ServerId).FirstOrDefault()?.ToMap(_mapper) ?? new()
+        };
+        response.SaveDataDB = Wire(stageSave);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -168,4 +168,25 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_TacticResult)]
+    public async Task<ScenarioTacticResultResponse> TacticResult(
+        SchaleDataContext db,
+        ScenarioTacticResultRequest request,
+        ScenarioTacticResultResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var (stageSave, isPlayerWin) = await _concentrateCampaignManager.ScenarioTacticResult(db, account, new CampaignTacticResultRequest
+        {
+            PassCheckCharacter = request.PassCheckCharacter,
+            Summary = request.Summary,
+            Hand = request.Hand,
+            SkipSummary = request.SkipSummary
+        });
+
+        response.SaveDataDB = Wire(stageSave);
+        response.IsPlayerWin = isPlayerWin;
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ScenarioMainStageHandler.cs
@@ -89,4 +89,23 @@ public class ScenarioMainStageHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Scenario_WithdrawEchelon)]
+    public async Task<ScenarioWithdrawEchelonResponse> WithdrawEchelon(
+        SchaleDataContext db,
+        ScenarioWithdrawEchelonRequest request,
+        ScenarioWithdrawEchelonResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var (stageSave, echelons) = await _eventContentCampaignManager.WithdrawEchelon(db, account, new EventContentWithdrawEchelonRequest
+        {
+            StageUniqueId = request.StageUniqueId,
+            WithdrawEchelonEntityId = request.WithdrawEchelonEntityId
+        });
+
+        response.SaveDataDB = Wire(stageSave);
+        response.WithdrawEchelonDBs = echelons;
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ShopHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ShopHandler.cs
@@ -515,16 +515,33 @@ public class ShopHandler : ProtocolHandlerBase
             return purchaseCount;
 
         // Logged rather than silently coerced: if this line never appears in a play session, the 10009 popups on
-        // single-unit buys come from somewhere else and this reading was wrong.
-        Serilog.Log.Warning("Shop purchase arrived with no PurchaseCount; charging one unit");
+        // single-unit buys come from somewhere else and this reading was wrong. Information, not Warning - the
+        // client sends 0 on every single-unit buy, so this fires constantly in normal play.
+        Serilog.Log.Information("Shop purchase arrived with no PurchaseCount; charging one unit");
         return 1;
     }
 
-    /// <summary>Parcels for one goods row, scaled by the purchase count. Columns are indexed to the shortest of the three so a ragged excel row degrades instead of throwing.</summary>
+    /// <summary>
+    /// The common length of a goods row's three parcel columns. A ragged row used to throw IndexOutOfRange
+    /// mid-purchase; truncating to the shortest column instead silently undercharged or dropped rewards, so
+    /// unequal lengths are rejected before any parcel is applied.
+    /// </summary>
+    internal static int AlignedColumnCount(int? types, int? ids, int? amounts)
+    {
+        var t = types ?? 0;
+        var i = ids ?? 0;
+        var a = amounts ?? 0;
+        if (t != i || t != a)
+            throw new WebAPIException(WebAPIErrorCode.ShopInvalidCostOrReward,
+                $"Ragged goods parcel columns (types:{t} ids:{i} amounts:{a})");
+        return t;
+    }
+
+    /// <summary>Parcels for one goods row, scaled by the purchase count.</summary>
     private static List<ParcelInfo> BuildParcels(
         List<ParcelType>? types, List<long>? ids, List<long>? amounts, long purchaseCount)
     {
-        var count = Math.Min(types?.Count ?? 0, Math.Min(ids?.Count ?? 0, amounts?.Count ?? 0));
+        var count = AlignedColumnCount(types?.Count, ids?.Count, amounts?.Count);
 
         var parcels = new List<ParcelInfo>(count);
         for (int i = 0; i < count; i++)

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/ShopHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/ShopHandler.cs
@@ -437,7 +437,7 @@ public class ShopHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
-        ValidatePurchaseCount(request.PurchaseCount);
+        var purchaseCount = NormalizePurchaseCount(request.PurchaseCount);
 
         var shopExcel = _excelService.GetTable<ShopExcelT>().FirstOrDefault(x => x.Id == request.ShopUniqueId);
         if (shopExcel == null)
@@ -448,35 +448,15 @@ public class ShopHandler : ProtocolHandlerBase
             throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {request.GoodsId} not found");
 
         var purchaseHistory = await ShopManager.EnsurePurchasable(
-            db, account, request.ShopUniqueId, shopExcel, request.PurchaseCount);
+            db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
-        var consumeParcelTypes = goodsExcel.ConsumeParcelType ?? [];
-        var consumeParcelIds = goodsExcel.ConsumeParcelId ?? [];
-        var consumeParcelAmounts = goodsExcel.ConsumeParcelAmount ?? [];
-
-        var rewardParcelTypes = goodsExcel.ParcelType ?? [];
-        var rewardParcelIds = goodsExcel.ParcelId ?? [];
-        var rewardParcelAmounts = goodsExcel.ParcelAmount ?? [];
-
-        var consumeParcels = new List<ParcelInfo>();
-        for (int i = 0; i < consumeParcelTypes.Count; i++)
-        {
-            consumeParcels.Add(new ParcelInfo
-            {
-                Key = new ParcelKeyPair { Type = consumeParcelTypes[i], Id = consumeParcelIds[i] },
-                Amount = consumeParcelAmounts[i] * request.PurchaseCount
-            });
-        }
-
-        var rewardParcels = new List<ParcelInfo>();
-        for (int i = 0; i < rewardParcelTypes.Count; i++)
-        {
-            rewardParcels.Add(new ParcelInfo
-            {
-                Key = new ParcelKeyPair { Type = rewardParcelTypes[i], Id = rewardParcelIds[i] },
-                Amount = rewardParcelAmounts[i] * request.PurchaseCount
-            });
-        }
+        // A goods row whose id/amount columns are shorter than its type column used to throw IndexOutOfRange out of
+        // these loops, which the client only ever sees as the generic failure popup (Shop_BuyRefreshMerchandise
+        // already indexes defensively for the same reason).
+        var consumeParcels = BuildParcels(
+            goodsExcel.ConsumeParcelType, goodsExcel.ConsumeParcelId, goodsExcel.ConsumeParcelAmount, purchaseCount);
+        var rewardParcels = BuildParcels(
+            goodsExcel.ParcelType, goodsExcel.ParcelId, goodsExcel.ParcelAmount, purchaseCount);
 
         if (consumeParcels.Count > 0)
         {
@@ -497,7 +477,7 @@ public class ShopHandler : ProtocolHandlerBase
             response.AccountCurrencyDB = accountCurrency.ToMap(_mapper);
         }
 
-        purchaseHistory.PurchaseCount += request.PurchaseCount;
+        purchaseHistory.PurchaseCount += purchaseCount;
 
         response.ShopProductDB = new ShopProductDB
         {
@@ -516,15 +496,47 @@ public class ShopHandler : ProtocolHandlerBase
         return response;
     }
 
-    // PurchaseCount arrives from the client and multiplies both the consume and the reward. A non-positive count inverts the consume into a grant (a -30-gem cost is credited, not debited), and a huge one overflows the int64 multiply back into negative territory, so the bound has to be two-sided.
+    // PurchaseCount arrives from the client and multiplies both the consume and the reward. A negative count inverts the consume into a grant (a -30-gem cost is credited, not debited), and a huge one overflows the int64 multiply back into negative territory, so the bound has to be two-sided.
     // The ceiling is far above any real shop's PurchaseCountLimit; per-shop limits are enforced separately in ShopManager.EnsurePurchasable.
     internal const long MaxPurchaseCountPerRequest = 10_000;
 
-    internal static void ValidatePurchaseCount(long purchaseCount)
+    /// <summary>
+    /// The count to actually charge and grant. An absent count deserializes to 0, and rejecting that made
+    /// single-unit buys fail with ShopInvalidCostOrReward while the same item bought in bulk went through;
+    /// a buy request means at least one. Negative and overflow-sized counts are still refused.
+    /// </summary>
+    internal static long NormalizePurchaseCount(long purchaseCount)
     {
-        if (purchaseCount is <= 0 or > MaxPurchaseCountPerRequest)
+        if (purchaseCount is < 0 or > MaxPurchaseCountPerRequest)
             throw new WebAPIException(WebAPIErrorCode.ShopInvalidCostOrReward,
                 $"Invalid purchase count {purchaseCount}");
+
+        if (purchaseCount > 0)
+            return purchaseCount;
+
+        // Logged rather than silently coerced: if this line never appears in a play session, the 10009 popups on
+        // single-unit buys come from somewhere else and this reading was wrong.
+        Serilog.Log.Warning("Shop purchase arrived with no PurchaseCount; charging one unit");
+        return 1;
+    }
+
+    /// <summary>Parcels for one goods row, scaled by the purchase count. Columns are indexed to the shortest of the three so a ragged excel row degrades instead of throwing.</summary>
+    private static List<ParcelInfo> BuildParcels(
+        List<ParcelType>? types, List<long>? ids, List<long>? amounts, long purchaseCount)
+    {
+        var count = Math.Min(types?.Count ?? 0, Math.Min(ids?.Count ?? 0, amounts?.Count ?? 0));
+
+        var parcels = new List<ParcelInfo>(count);
+        for (int i = 0; i < count; i++)
+        {
+            parcels.Add(new ParcelInfo
+            {
+                Key = new ParcelKeyPair { Type = types![i], Id = ids![i] },
+                Amount = amounts![i] * purchaseCount
+            });
+        }
+
+        return parcels;
     }
 
     [ProtocolHandler(Protocol.Shop_BuyRefreshMerchandise)]
@@ -639,7 +651,7 @@ public class ShopHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
-        ValidatePurchaseCount(request.PurchaseCount);
+        var purchaseCount = NormalizePurchaseCount(request.PurchaseCount);
 
         var shopExcel = _excelService.GetTable<ShopExcelT>().FirstOrDefault(x => x.Id == request.ShopUniqueId);
         if (shopExcel == null)
@@ -650,27 +662,12 @@ public class ShopHandler : ProtocolHandlerBase
             throw new WebAPIException(WebAPIErrorCode.ShopGoodsNotFound, $"Goods {request.GoodsUniqueId} not found");
 
         var purchaseHistory = await ShopManager.EnsurePurchasable(
-            db, account, request.ShopUniqueId, shopExcel, request.PurchaseCount);
+            db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
-        var consumeParcels = new List<ParcelInfo>();
-        for (int i = 0; i < (goodsExcel.ConsumeParcelType ?? []).Count; i++)
-        {
-            consumeParcels.Add(new ParcelInfo
-            {
-                Key = new ParcelKeyPair { Type = goodsExcel.ConsumeParcelType[i], Id = goodsExcel.ConsumeParcelId[i] },
-                Amount = goodsExcel.ConsumeParcelAmount[i] * request.PurchaseCount
-            });
-        }
-
-        var rewardParcels = new List<ParcelInfo>();
-        for (int i = 0; i < (goodsExcel.ParcelType ?? []).Count; i++)
-        {
-            rewardParcels.Add(new ParcelInfo
-            {
-                Key = new ParcelKeyPair { Type = goodsExcel.ParcelType[i], Id = goodsExcel.ParcelId[i] },
-                Amount = goodsExcel.ParcelAmount[i] * request.PurchaseCount
-            });
-        }
+        var consumeParcels = BuildParcels(
+            goodsExcel.ConsumeParcelType, goodsExcel.ConsumeParcelId, goodsExcel.ConsumeParcelAmount, purchaseCount);
+        var rewardParcels = BuildParcels(
+            goodsExcel.ParcelType, goodsExcel.ParcelId, goodsExcel.ParcelAmount, purchaseCount);
 
         var consumeResolver = await _parcelHandler.BuildParcel(db, account, consumeParcels, isConsume: true);
 
@@ -686,7 +683,7 @@ public class ShopHandler : ProtocolHandlerBase
         parcelResultDB.AcquiredItems = rewardParcels;
         response.ParcelResultDB = parcelResultDB;
 
-        purchaseHistory.PurchaseCount += request.PurchaseCount;
+        purchaseHistory.PurchaseCount += purchaseCount;
 
         response.ShopProductDB = new ShopProductDB
         {
@@ -722,7 +719,7 @@ public class ShopHandler : ProtocolHandlerBase
     {
         var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
 
-        ValidatePurchaseCount(request.PurchaseCount);
+        var purchaseCount = NormalizePurchaseCount(request.PurchaseCount);
 
         // Failures are Error packets, never empty successes - official rejects with a bare {Protocol:-1, ErrorCode, ServerTimeTicks} envelope (captured on the AP-cap rejection).
         var shopExcel = _excelService.GetTable<ShopExcelT>().FirstOrDefault(x => x.Id == request.ShopUniqueId);
@@ -741,7 +738,7 @@ public class ShopHandler : ProtocolHandlerBase
             : (long)CurrencyTypes.Gem;
         var costAmount = (goodsExcel.ConsumeParcelAmount != null && goodsExcel.ConsumeParcelAmount.Count > 0 
             ? goodsExcel.ConsumeParcelAmount[0] 
-            : 0) * request.PurchaseCount;
+            : 0) * purchaseCount;
 
         var costCurrency = costParcelType == ParcelType.Currency ? (CurrencyTypes)costParcelId : CurrencyTypes.Gem;
         
@@ -761,11 +758,11 @@ public class ShopHandler : ProtocolHandlerBase
             && rewardParcelId == (long)CurrencyTypes.ActionPoint
             && rewardPerCount is > 0 and <= 999
                 ? rewardPerCount
-                : 120) * request.PurchaseCount;
+                : 120) * purchaseCount;
         
         // The AP shop is capped at 20 purchases per game day (PurchaseCountLimit in the excel, confirmed on the wire); tracked per reset window so the counter rolls over at 04:00.
         var purchaseHistory = await ShopManager.EnsurePurchasable(
-            db, account, request.ShopUniqueId, shopExcel, request.PurchaseCount);
+            db, account, request.ShopUniqueId, shopExcel, purchaseCount);
 
         var accountCurrency = db.GetAccountCurrencies(account.ServerId).FirstOrDefault();
         if (accountCurrency == null)
@@ -793,7 +790,7 @@ public class ShopHandler : ProtocolHandlerBase
         accountCurrency.CurrencyDict[rewardCurrency] += rewardAmount;
         accountCurrency.UpdateTimeDict[rewardCurrency] = account.GameSettings.ServerDateTime();
 
-        purchaseHistory.PurchaseCount += request.PurchaseCount;
+        purchaseHistory.PurchaseCount += purchaseCount;
 
         await db.SaveChangesAsync();
 
@@ -829,9 +826,13 @@ public class ShopHandler : ProtocolHandlerBase
         };
 
         var buyApMissions = _missionService.UpdateMissionProgress(
-            db, account, MissionCompleteConditionType.Reset_ShopBuyActionPointCount, request.PurchaseCount);
+            db, account, MissionCompleteConditionType.Reset_ShopBuyActionPointCount, purchaseCount);
         if (buyApMissions.Count > 0)
             response.MissionProgressDBs = buyApMissions;
+
+        // UpdateMissionProgress only stages the rows; the SaveChanges above already ran, so without this the
+        // client is told the mission moved and the next Mission_List says it never did.
+        await db.SaveChangesAsync();
 
         return response;
     }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/SkipHistoryHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/SkipHistoryHandler.cs
@@ -28,4 +28,19 @@ public class SkipHistoryHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.SkipHistory_Save)]
+    public async Task<SkipHistorySaveResponse> Save(
+        SchaleDataContext db,
+        SkipHistorySaveRequest request,
+        SkipHistorySaveResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        account.GameSettings.SkipHistory = request.SkipHistoryDB;
+        db.Accounts.Update(account);
+        await db.SaveChangesAsync();
+
+        response.SkipHistoryDB = account.GameSettings.SkipHistory;
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/SkipHistoryHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/SkipHistoryHandler.cs
@@ -1,0 +1,19 @@
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class SkipHistoryHandler : ProtocolHandlerBase
+{
+    private readonly ISessionKeyService _sessionService;
+
+    public SkipHistoryHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService) : base(registry)
+    {
+        _sessionService = sessionService;
+    }
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/SkipHistoryHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/SkipHistoryHandler.cs
@@ -16,4 +16,16 @@ public class SkipHistoryHandler : ProtocolHandlerBase
         _sessionService = sessionService;
     }
 
+    [ProtocolHandler(Protocol.SkipHistory_List)]
+    public async Task<SkipHistoryListResponse> List(
+        SchaleDataContext db,
+        SkipHistoryListRequest request,
+        SkipHistoryListResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.SkipHistoryDB = account.GameSettings.SkipHistory;
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/StickerHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/StickerHandler.cs
@@ -72,4 +72,28 @@ public class StickerHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Sticker_UseSticker)]
+    public async Task<StickerUseStickerResponse> UseSticker(
+        SchaleDataContext db,
+        StickerUseStickerRequest request,
+        StickerUseStickerResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var book = db.GetAccountStickerBooks(account.ServerId).First();
+        book.UnusedStickerDBs ??= [];
+        book.UsedStickerDBs ??= [];
+
+        var sticker = book.UnusedStickerDBs.FirstOrDefault(x => x.StickerUniqueId == request.StickerUniqueId);
+        if (sticker != null)
+        {
+            book.UnusedStickerDBs.Remove(sticker);
+            book.UsedStickerDBs.Add(sticker);
+            db.StickerBooks.Update(book);
+            await db.SaveChangesAsync();
+        }
+
+        response.StickerBookDB = book.ToMap(_mapper);
+        return response;
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/StickerHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/StickerHandler.cs
@@ -34,4 +34,42 @@ public class StickerHandler : ProtocolHandlerBase
         return response;
     }
 
+    [ProtocolHandler(Protocol.Sticker_Lobby)]
+    public async Task<StickerLobbyResponse> Lobby(
+        SchaleDataContext db,
+        StickerLobbyRequest request,
+        StickerLobbyResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        var book = db.GetAccountStickerBooks(account.ServerId).First();
+        book.UnusedStickerDBs ??= [];
+        book.UsedStickerDBs ??= [];
+
+        var received = new List<StickerDBServer>();
+        foreach (var id in request.AcquireStickerUniqueIds ?? [])
+        {
+            var owned = book.UnusedStickerDBs.Any(x => x.StickerUniqueId == id)
+                || book.UsedStickerDBs.Any(x => x.StickerUniqueId == id);
+            if (owned)
+                continue;
+
+            var sticker = new StickerDBServer
+            {
+                AccountServerId = account.ServerId,
+                StickerUniqueId = id
+            };
+            db.Stickers.Add(sticker);
+            book.UnusedStickerDBs.Add(sticker);
+            received.Add(sticker);
+        }
+
+        db.StickerBooks.Update(book);
+        await db.SaveChangesAsync();
+
+        response.ReceivedStickerDBs = received.ToMapList(_mapper);
+        response.StickerBookDB = book.ToMap(_mapper);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/StickerHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/StickerHandler.cs
@@ -22,4 +22,16 @@ public class StickerHandler : ProtocolHandlerBase
         _mapper = mapper;
     }
 
+    [ProtocolHandler(Protocol.Sticker_Login)]
+    public async Task<StickerLoginResponse> Login(
+        SchaleDataContext db,
+        StickerLoginRequest request,
+        StickerLoginResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        response.StickerBookDB = db.GetAccountStickerBooks(account.ServerId).FirstMapTo(_mapper);
+        return response;
+    }
+
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/StickerHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/StickerHandler.cs
@@ -1,0 +1,25 @@
+using AutoMapper;
+using BlueArchiveAPI.Services;
+using Schale.Data;
+using Schale.Data.GameModel;
+using Schale.Data.ModelMapping;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class StickerHandler : ProtocolHandlerBase
+{
+    private readonly ISessionKeyService _sessionService;
+    private readonly IMapper _mapper;
+
+    public StickerHandler(
+        IProtocolHandlerRegistry registry,
+        ISessionKeyService sessionService,
+        IMapper mapper) : base(registry)
+    {
+        _sessionService = sessionService;
+        _mapper = mapper;
+    }
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/SystemHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/SystemHandler.cs
@@ -1,0 +1,14 @@
+using BlueArchiveAPI.Configuration;
+using Schale.Data;
+using Schale.MX.NetworkProtocol;
+using Shittim_Server.Core;
+
+namespace Shittim_Server.Core.NetworkProtocol.Handlers;
+
+public class SystemHandler : ProtocolHandlerBase
+{
+    public SystemHandler(IProtocolHandlerRegistry registry) : base(registry)
+    {
+    }
+
+}

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/SystemHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/SystemHandler.cs
@@ -11,4 +11,17 @@ public class SystemHandler : ProtocolHandlerBase
     {
     }
 
+    [ProtocolHandler(Protocol.System_Version)]
+    public Task<SystemVersionResponse> Version(
+        SchaleDataContext db,
+        SystemVersionRequest request,
+        SystemVersionResponse response)
+    {
+        // Same answers Account_Auth gives: the server's data-build number, no minimum, not a dev build.
+        response.CurrentVersion = Config.Instance.ServerConfiguration.AuthCurrentVersion;
+        response.MinimumVersion = 0;
+        response.IsDevelopment = false;
+
+        return Task.FromResult(response);
+    }
 }

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/TTSHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/TTSHandler.cs
@@ -16,6 +16,20 @@ public class TTSHandler : ProtocolHandlerBase
         _sessionService = sessionService;
     }
 
+    [ProtocolHandler(Protocol.TTS_GetFile)]
+    public async Task<TTSGetFileResponse> GetFile(
+        SchaleDataContext db,
+        TTSGetFileRequest request,
+        TTSGetFileResponse response)
+    {
+        await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        // No TTS synthesis pipeline on this server; "not ready" makes the client fall back to the stock voice line.
+        response.IsFileReady = false;
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.TTS_GetKana)]
     public async Task<TTSGetKanaResponse> GetKana(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/TimeAttackDungeonHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/TimeAttackDungeonHandler.cs
@@ -38,6 +38,89 @@ public class TimeAttackDungeonHandler : ProtocolHandlerBase
         _parcelHandler = parcelHandler;
     }
 
+    [ProtocolHandler(Protocol.TimeAttackDungeon_Sweep)]
+    public async Task<TimeAttackDungeonSweepResponse> Sweep(
+        SchaleDataContext db,
+        TimeAttackDungeonSweepRequest request,
+        TimeAttackDungeonSweepResponse response)
+    {
+        var account = await _sessionService.GetAuthenticatedUser(db, request.SessionKey);
+
+        if (request.SweepCount < 1)
+            throw new WebAPIException(WebAPIErrorCode.TimeAttackDungeonInvalidRequest, "SweepCount must be positive");
+
+        var info = account.ContentInfo.TimeAttackDungeonDataInfo;
+        var season = _excelService.GetTable<TimeAttackDungeonSeasonManageExcelT>()
+                .FirstOrDefault(x => x.Id == info.SeasonId)
+            ?? throw new WebAPIException(WebAPIErrorCode.TimeAttackDungeonNotOpen, $"Season {info.SeasonId} not found");
+
+        // A sweep replays the best clear; with nothing cleared there is nothing to replay.
+        if (info.SeasonBestRecord <= 0)
+            throw new WebAPIException(WebAPIErrorCode.TimeAttackDungeonInvalidRequest, "No cleared run to sweep");
+
+        var reward = _excelService.GetTable<TimeAttackDungeonRewardExcelT>()
+                .FirstOrDefault(x => x.Id == season.TimeAttackDungeonRewardId)
+            ?? throw new WebAPIException(WebAPIErrorCode.TimeAttackDungeonInvalidData, $"Reward {season.TimeAttackDungeonRewardId} not found");
+
+        var currency = db.Currencies.FirstOrDefault(x => x.AccountServerId == account.ServerId);
+        if (currency == null
+            || !currency.CurrencyDict.TryGetValue(CurrencyTypes.TimeAttackDungeonTicket, out var tickets)
+            || tickets < request.SweepCount)
+        {
+            throw new WebAPIException(WebAPIErrorCode.TimeAttackDungeonInvalidRequest, "Not enough tickets");
+        }
+
+        await _parcelHandler.BuildParcel(db, account,
+            new ParcelResult(ParcelType.Currency, (long)CurrencyTypes.TimeAttackDungeonTicket, request.SweepCount),
+            isConsume: true);
+
+        var columns = ShopHandler.AlignedColumnCount(
+            reward.RewardParcelType?.Count, reward.RewardParcelId?.Count, reward.RewardParcelDefaultAmount?.Count);
+        // The point ratio scales each parcel between its default and max amounts; the official curve is unknown,
+        // bounded here by the excel's own Default..Max so it cannot run away.
+        var ratio = reward.RewardMaxPoint > 0
+            ? System.Math.Clamp(info.SeasonBestRecord / (double)reward.RewardMaxPoint, 0d, 1d)
+            : 0d;
+
+        var perSweep = new List<ParcelInfo>();
+        for (int i = 0; i < columns; i++)
+        {
+            if (reward.RewardMinPoint != null && i < reward.RewardMinPoint.Count
+                && info.SeasonBestRecord < reward.RewardMinPoint[i])
+            {
+                continue;
+            }
+
+            var min = reward.RewardParcelDefaultAmount![i];
+            var max = (reward.RewardParcelMaxAmount != null && i < reward.RewardParcelMaxAmount.Count)
+                ? reward.RewardParcelMaxAmount[i]
+                : min;
+            var amount = min + (long)((max - min) * ratio);
+            if (amount <= 0)
+                continue;
+
+            perSweep.Add(new ParcelInfo
+            {
+                Key = new ParcelKeyPair { Type = reward.RewardParcelType![i], Id = reward.RewardParcelId![i] },
+                Amount = amount
+            });
+        }
+
+        var all = new List<ParcelResult>();
+        response.Rewards = [];
+        for (int n = 0; n < request.SweepCount; n++)
+        {
+            response.Rewards.Add(perSweep);
+            all.AddRange(perSweep.Select(x => new ParcelResult(x.Key!.Type, x.Key.Id, x.Amount)));
+        }
+
+        var resolver = await _parcelHandler.BuildParcel(db, account, all);
+        response.ParcelResultDB = resolver.ParcelResult;
+        response.RoomDB = _timeAttackDungeonManager.GetRoom(db, account)?.ToMap(_mapper);
+
+        return response;
+    }
+
     [ProtocolHandler(Protocol.TimeAttackDungeon_Login)]
     public async Task<TimeAttackDungeonLoginResponse> Login(
         SchaleDataContext db,

--- a/Shittim-Server/Core/NetworkProtocol/Handlers/TimeAttackDungeonHandler.cs
+++ b/Shittim-Server/Core/NetworkProtocol/Handlers/TimeAttackDungeonHandler.cs
@@ -20,16 +20,22 @@ public class TimeAttackDungeonHandler : ProtocolHandlerBase
     private readonly ISessionKeyService _sessionService;
     private readonly TimeAttackDungeonManager _timeAttackDungeonManager;
     private readonly IMapper _mapper;
+    private readonly ExcelTableService _excelService;
+    private readonly ParcelHandler _parcelHandler;
 
     public TimeAttackDungeonHandler(
         IProtocolHandlerRegistry registry,
         ISessionKeyService sessionService,
         TimeAttackDungeonManager timeAttackDungeonManager,
-        IMapper mapper) : base(registry)
+        IMapper mapper,
+        ExcelTableService excelService,
+        ParcelHandler parcelHandler) : base(registry)
     {
         _sessionService = sessionService;
         _timeAttackDungeonManager = timeAttackDungeonManager;
         _mapper = mapper;
+        _excelService = excelService;
+        _parcelHandler = parcelHandler;
     }
 
     [ProtocolHandler(Protocol.TimeAttackDungeon_Login)]

--- a/Shittim-Server/GameMasters/CharacterGM.cs
+++ b/Shittim-Server/GameMasters/CharacterGM.cs
@@ -548,13 +548,14 @@ namespace Shittim.GameMasters
                         await connection.SendChatMessage("Invalid level parameter!");
                     break;
                 case "star":
-                    if (int.TryParse(parameters, out int star))
+                    // Bounded: the client draws five slots and a grade outside them is a value it cannot render.
+                    if (int.TryParse(parameters, out int star) && star is >= 1 and <= 5)
                     {
                         character.StarGrade = star;
                         await connection.SendChatMessage($"Character {characterId} star grade set to {star}");
                     }
                     else
-                        await connection.SendChatMessage("Invalid star parameter!");
+                        await connection.SendChatMessage("Invalid star parameter! Expected 1-5.");
                     break;
                 case "skill":
                     var skillLevels = parameters.Split(' ');

--- a/Shittim-Server/GameMasters/CharacterGM.cs
+++ b/Shittim-Server/GameMasters/CharacterGM.cs
@@ -602,46 +602,54 @@ namespace Shittim.GameMasters
             switch (option.ToLower())
             {
                 case "level":
-                    if (int.TryParse(parameters, out int level))
+                    if (!int.TryParse(parameters, out int level))
                     {
-                        foreach (var character in allCharacters)
-                            character.Level = level;
+                        await connection.SendChatMessage("Invalid level parameter!");
+                        return;
                     }
+                    foreach (var character in allCharacters)
+                        character.Level = level;
                     break;
                 case "star":
                     // Same bound as the single-character path: the client draws five slots.
-                    if (int.TryParse(parameters, out int star) && star is >= 1 and <= 5)
+                    if (!int.TryParse(parameters, out int star) || star is < 1 or > 5)
                     {
-                        foreach (var character in allCharacters)
-                            character.StarGrade = star;
+                        await connection.SendChatMessage("Invalid star parameter! Expected 1-5.");
+                        return;
                     }
+                    foreach (var character in allCharacters)
+                        character.StarGrade = star;
                     break;
                 case "skill":
                     var skillLevels = parameters.Split(' ');
-                    if (skillLevels.Length == 4 && skillLevels.All(x => int.TryParse(x, out _)))
+                    if (skillLevels.Length != 4 || !skillLevels.All(x => int.TryParse(x, out _)))
                     {
-                        foreach (var character in allCharacters)
-                        {
-                            character.ExSkillLevel = int.Parse(skillLevels[0]);
-                            character.PublicSkillLevel = int.Parse(skillLevels[1]);
-                            character.PassiveSkillLevel = int.Parse(skillLevels[2]);
-                            character.ExtraPassiveSkillLevel = int.Parse(skillLevels[3]);
-                        }
+                        await connection.SendChatMessage("Invalid skill levels! Format: {skill1 skill2 skill3 skill4}");
+                        return;
+                    }
+                    foreach (var character in allCharacters)
+                    {
+                        character.ExSkillLevel = int.Parse(skillLevels[0]);
+                        character.PublicSkillLevel = int.Parse(skillLevels[1]);
+                        character.PassiveSkillLevel = int.Parse(skillLevels[2]);
+                        character.ExtraPassiveSkillLevel = int.Parse(skillLevels[3]);
                     }
                     break;
                 case "ps":
                     var potentialStats = parameters.Split(' ');
-                    if (potentialStats.Length == 3 && potentialStats.All(x => int.TryParse(x, out _)))
+                    if (potentialStats.Length != 3 || !potentialStats.All(x => int.TryParse(x, out _)))
                     {
-                        foreach (var character in allCharacters)
+                        await connection.SendChatMessage("Invalid potential stats! Format: {ps1 ps2 ps3}");
+                        return;
+                    }
+                    foreach (var character in allCharacters)
+                    {
+                        character.PotentialStats = new Dictionary<int, int>
                         {
-                            character.PotentialStats = new Dictionary<int, int>
-                            {
-                                { 1, int.Parse(potentialStats[0]) },
-                                { 2, int.Parse(potentialStats[1]) },
-                                { 3, int.Parse(potentialStats[2]) }
-                            };
-                        }
+                            { 1, int.Parse(potentialStats[0]) },
+                            { 2, int.Parse(potentialStats[1]) },
+                            { 3, int.Parse(potentialStats[2]) }
+                        };
                     }
                     break;
                 default:

--- a/Shittim-Server/GameMasters/CharacterGM.cs
+++ b/Shittim-Server/GameMasters/CharacterGM.cs
@@ -609,7 +609,8 @@ namespace Shittim.GameMasters
                     }
                     break;
                 case "star":
-                    if (int.TryParse(parameters, out int star))
+                    // Same bound as the single-character path: the client draws five slots.
+                    if (int.TryParse(parameters, out int star) && star is >= 1 and <= 5)
                     {
                         foreach (var character in allCharacters)
                             character.StarGrade = star;

--- a/Shittim-Server/Managers/CampaignManager.cs
+++ b/Shittim-Server/Managers/CampaignManager.cs
@@ -3,6 +3,7 @@ using Schale.Data;
 using Schale.Data.GameModel;
 using Schale.FlatData;
 using Schale.Excel;
+using Schale.MX.Campaign;
 using Schale.MX.GameLogic.Parcel;
 using Schale.MX.NetworkProtocol;
 using Schale.MX.Logic.Battles.Summary;
@@ -362,6 +363,122 @@ namespace Shittim_Server.Managers
         {
             if (probability == 0) return true;
             return Random.Shared.Next(10000) < probability;
+        }
+
+        // The client's IsAvailableStageToday reads TodayPurchasePlayCountHardStage, so the history counter
+        // still moves; the limit itself lives in the resetable-content ledger and returns with its window.
+        public async Task<(AccountCurrencyDBServer Currency, CampaignStageHistoryDBServer History)> PurchasePlayCountHardStage(
+            SchaleDataContext context,
+            AccountDBServer account,
+            long stageUniqueId)
+        {
+            var isHard = _campaignChapterExcels.Any(x =>
+                (x.HardCampaignStageId?.Contains(stageUniqueId) ?? false)
+                || (x.VeryHardCampaignStageId?.Contains(stageUniqueId) ?? false));
+            if (!isHard)
+                throw new WebAPIException(WebAPIErrorCode.CampaignStagePlayLimit, $"Stage {stageUniqueId} has no purchasable plays");
+
+            var window = ResetableContentService.ResetWindow;
+            var purchased = ResetableContentService.LiveValue(
+                account, ResetContentType.HardStagePlay, stageUniqueId, window);
+
+            var purchaseLimit = _excelService.GetTable<ConstCommonExcelT>().First().HardAdventurePlayCountRecoverDailyNumber;
+            if (purchased >= purchaseLimit)
+                throw new WebAPIException(WebAPIErrorCode.CampaignStagePlayLimit, $"Stage {stageUniqueId} has no purchases left this window");
+
+            // the price is not a constant anywhere - ServiceActionExcel names the goods row and the goods row is what carries the currency and the amount
+            var serviceAction = _excelService.GetTable<ServiceActionExcelT>()
+                .FirstOrDefault(x => x.ServiceActionType == ServiceActionType.HardAdventurePlayCountRecover);
+            var goods = serviceAction == null
+                ? null
+                : _excelService.GetTable<GoodsExcelT>().FirstOrDefault(x => x.Id == serviceAction.GoodsId);
+
+            if (goods != null)
+            {
+                var cost = ParcelResult.ConvertParcelResult(goods.ConsumeParcelType, goods.ConsumeParcelId, goods.ConsumeParcelAmount);
+                await _parcelHandler.BuildParcel(context, account, cost, isConsume: true);
+            }
+
+            var historyDb = context.CampaignStageHistories
+                .FirstOrDefault(x => x.AccountServerId == account.ServerId && x.StageUniqueId == stageUniqueId);
+            if (historyDb == null)
+            {
+                historyDb = new CampaignStageHistoryDBServer
+                {
+                    AccountServerId = account.ServerId,
+                    StageUniqueId = stageUniqueId,
+                    LastPlay = account.GameSettings.ServerDateTime()
+                };
+                context.CampaignStageHistories.Add(historyDb);
+            }
+
+            historyDb.TodayPurchasePlayCountHardStage++;
+            ResetableContentService.Bump(
+                account, ResetContentType.HardStagePlay, stageUniqueId, window);
+            context.Accounts.Update(account);
+
+            await context.SaveChangesAsync();
+
+            var currency = context.Currencies.First(x => x.AccountServerId == account.ServerId);
+            return (currency, historyDb);
+        }
+
+        public async Task<(AccountCurrencyDBServer Currency, CampaignMainStageSaveDBServer Save)> Heal(
+            SchaleDataContext context,
+            AccountDBServer account,
+            long stageUniqueId,
+            long echelonIndex,
+            long characterServerId)
+        {
+            var save = context.CampaignMainStageSaves.FirstOrDefault(x =>
+                    x.AccountServerId == account.ServerId && x.IsOpen && x.StageUniqueId == stageUniqueId)
+                ?? throw new WebAPIException(WebAPIErrorCode.CampaignStageHealNotAcceptable,
+                    $"No open run on stage {stageUniqueId}");
+
+            // EchelonInfos is keyed by the deploy-time EntityId; fall back to whichever deployed unit carries
+            // the character so an index the client counts differently still heals the right student.
+            HexaUnit? unit = null;
+            if (save.EchelonInfos != null && save.EchelonInfos.TryGetValue(echelonIndex, out var byIndex)
+                && byIndex.HpInfos?.ContainsKey(characterServerId) == true)
+            {
+                unit = byIndex;
+            }
+            unit ??= save.EchelonInfos?.Values.FirstOrDefault(u => u.HpInfos?.ContainsKey(characterServerId) == true)
+                ?? throw new WebAPIException(WebAPIErrorCode.CampaignStageHealNotAcceptable,
+                    $"Character {characterServerId} is not deployed on stage {stageUniqueId}");
+
+            var constStrategy = _excelService.GetTable<ConstStrategyExcelT>().First();
+            if (unit.HpInfos![characterServerId] >= constStrategy.CanHealHpRate)
+                throw new WebAPIException(WebAPIErrorCode.CampaignStageHealNotAcceptable,
+                    $"Character {characterServerId} is above the heal threshold");
+
+            var window = ResetableContentService.ResetWindow;
+            var healsUsed = ResetableContentService.LiveValue(
+                account, ResetContentType.StarategyMapHeal, 0, window);
+
+            var costs = constStrategy.HealCostAmount ?? [];
+            if (costs.Count > 0 && healsUsed >= costs.Count)
+                throw new WebAPIException(WebAPIErrorCode.CampaignStageHealLimit, "No heals left this window");
+
+            var cost = costs.Count > 0 ? costs[(int)healsUsed] : 0;
+            if (cost > 0)
+            {
+                await _parcelHandler.BuildParcel(context, account,
+                    new ParcelResult(ParcelType.Currency, (long)constStrategy.HealCostType, cost), isConsume: true);
+            }
+
+            unit.HpInfos[characterServerId] = ConcentrateCampaignManager.FullHpRate;
+            unit.DyingInfos?.Remove(characterServerId);
+            context.Entry(save).Property(x => x.EchelonInfos).IsModified = true;
+
+            ResetableContentService.Bump(
+                account, ResetContentType.StarategyMapHeal, 0, window);
+            context.Accounts.Update(account);
+
+            await context.SaveChangesAsync();
+
+            var currency = context.Currencies.First(x => x.AccountServerId == account.ServerId);
+            return (currency, save);
         }
     }
 }

--- a/Shittim-Server/Managers/ConquestManager.cs
+++ b/Shittim-Server/Managers/ConquestManager.cs
@@ -1,0 +1,238 @@
+using Schale.Data;
+using Schale.Data.GameModel;
+using Schale.FlatData;
+using Schale.MX.GameLogic.DBModel;
+using Schale.MX.GameLogic.Parcel;
+using Schale.MX.Logic.Battles;
+using Schale.MX.Logic.Battles.Summary;
+using Schale.MX.NetworkProtocol;
+using BlueArchiveAPI.Services;
+using Shittim_Server.Services;
+
+namespace Shittim_Server.Managers
+{
+    // Tiles are conquered (free ones directly, battle tiles through the start/result pair), bases produce
+    // and upgrade, a step opens when its playable tiles are all taken, and the calculate gauge pays per threshold.
+    // Nothing spawns erosion, unexpected enemies or treasure boxes, so the five object handlers are
+    // guard-only. The blocker is not the data - ConquestObjectExcel, ConquestErosionExcel and their
+    // condition columns are all populated - it is TypedJsonWrapper<T> (Schale/MX/Core/Services/Services.cs),
+    // whose implicit operator drops the object and leaves JsonWithType empty. Every conquest response
+    // carries its objects through that wrapper, so spawned rows could not reach the client. Implementing it
+    // needs the client's exact $type token, which no capture here pins down.
+    public class ConquestManager
+    {
+        private readonly ExcelTableService _excelService;
+        private readonly ParcelHandler _parcelHandler;
+
+        public ConquestManager(ExcelTableService excelService, ParcelHandler parcelHandler)
+        {
+            _excelService = excelService;
+            _parcelHandler = parcelHandler;
+        }
+
+        public ConquestInfoDBServer GetOrCreate(SchaleDataContext db, AccountDBServer account, long eventContentId)
+        {
+            var hasEvent = _excelService.GetTable<ConquestEventExcelT>()
+                .Any(x => x.EventContentId == eventContentId || x.MainStoryEventContentId == eventContentId);
+            if (!hasEvent && !_excelService.GetTable<ConquestTileExcelT>().Any(x => x.EventId == eventContentId))
+                throw new WebAPIException(WebAPIErrorCode.ConquestDataNotFound, $"No conquest data for event {eventContentId}");
+
+            var row = db.GetAccountConquestInfos(account.ServerId).FirstOrDefault(x => x.EventContentId == eventContentId);
+            if (row == null)
+            {
+                row = new ConquestInfoDBServer
+                {
+                    AccountServerId = account.ServerId,
+                    EventContentId = eventContentId,
+                    StepByDifficulty = new Dictionary<StageDifficulty, int> { [StageDifficulty.Normal] = 0 }
+                };
+                db.ConquestInfos.Add(row);
+                db.SaveChanges();
+            }
+
+            return row;
+        }
+
+        public ConquestInfoDBServer Require(SchaleDataContext db, AccountDBServer account, long eventContentId)
+        {
+            return db.GetAccountConquestInfos(account.ServerId).FirstOrDefault(x => x.EventContentId == eventContentId)
+                ?? throw new WebAPIException(WebAPIErrorCode.ConquestDataNotFound, $"No conquest progress for event {eventContentId}");
+        }
+
+        public long CalculateConditionAmount(long eventContentId)
+        {
+            return _excelService.GetTable<ConquestCalculateExcelT>()
+                .FirstOrDefault(x => x.EventContentId == eventContentId)?.CalculateConditionParcelAmount ?? 0;
+        }
+
+        public ConquestTileExcelT RequireTile(long eventContentId, long tileUniqueId)
+        {
+            return _excelService.GetTable<ConquestTileExcelT>()
+                    .FirstOrDefault(x => x.Id == tileUniqueId && x.EventId == eventContentId)
+                ?? throw new WebAPIException(WebAPIErrorCode.ConquestDataNotFound,
+                    $"Tile {tileUniqueId} not in event {eventContentId}");
+        }
+
+        public ConquestTileDB? StoredTile(ConquestInfoDBServer info, StageDifficulty difficulty, long tileUniqueId)
+            => info.Tiles.FirstOrDefault(x => x.Difficulty == difficulty && x.TileUniqueId == tileUniqueId);
+
+        public int CurrentStep(ConquestInfoDBServer info, StageDifficulty difficulty)
+            => info.StepByDifficulty.TryGetValue(difficulty, out var step) ? step : 0;
+
+        // Free (non-battle) tiles conquer directly; battle tiles must go through the start/result pair.
+        public async Task<(ConquestTileDB Tile, ParcelResultDB ParcelResult, Dictionary<RewardTag, List<ParcelInfo>> ByTag)> Conquer(
+            SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
+            StageDifficulty difficulty, long tileUniqueId, bool throughBattle)
+        {
+            var tileExcel = RequireTile(info.EventContentId, tileUniqueId);
+
+            if (tileExcel.Step > CurrentStep(info, difficulty))
+                throw new WebAPIException(WebAPIErrorCode.ConquestStepNotOpened,
+                    $"Tile {tileUniqueId} is on step {tileExcel.Step}");
+            if (StoredTile(info, difficulty, tileUniqueId) != null)
+                throw new WebAPIException(WebAPIErrorCode.ConquestAlreadyConquested, $"Tile {tileUniqueId} already taken");
+
+            var isBattleTile = tileExcel.TileType == ConquestTileType.Battle;
+            if (isBattleTile != throughBattle)
+                throw new WebAPIException(WebAPIErrorCode.ConquestInvalidTileType,
+                    $"Tile {tileUniqueId} is {tileExcel.TileType}");
+
+            var parcels = new List<ParcelResult>();
+            if (tileExcel.ConquestCostType != ParcelType.None && tileExcel.ConquestCostAmount > 0)
+            {
+                await _parcelHandler.BuildParcel(db, account,
+                    new ParcelResult(tileExcel.ConquestCostType, tileExcel.ConquestCostId, tileExcel.ConquestCostAmount),
+                    isConsume: true);
+                TrackConditionSpend(info, tileExcel.ConquestCostType, tileExcel.ConquestCostId, tileExcel.ConquestCostAmount);
+            }
+
+            var byTag = RollRewardGroup(tileExcel.ConquestRewardId, parcels);
+            var resolver = await _parcelHandler.BuildParcel(db, account, parcels);
+
+            var tile = new ConquestTileDB
+            {
+                EventContentId = info.EventContentId,
+                Difficulty = difficulty,
+                TileUniqueId = tileUniqueId,
+                TileState = TileState.FullyConquested,
+                Level = 1,
+                CreateTime = account.GameSettings.ServerDateTime()
+            };
+            info.Tiles.Add(tile);
+            AdvanceStepIfCleared(info, difficulty);
+            db.ConquestInfos.Update(info);
+            await db.SaveChangesAsync();
+
+            return (tile, resolver.ParcelResult, byTag);
+        }
+
+        public void AdvanceStepIfCleared(ConquestInfoDBServer info, StageDifficulty difficulty)
+        {
+            var step = CurrentStep(info, difficulty);
+            var stepTiles = _excelService.GetTable<ConquestTileExcelT>()
+                .Where(x => x.EventId == info.EventContentId && x.Step == step && x.Playable)
+                .Select(x => x.Id)
+                .ToHashSet();
+
+            if (stepTiles.Count == 0)
+                return;
+
+            var conquered = info.Tiles
+                .Where(x => x.Difficulty == difficulty)
+                .Select(x => x.TileUniqueId)
+                .ToHashSet();
+
+            if (!stepTiles.IsSubsetOf(conquered))
+                return;
+
+            var maxStep = _excelService.GetTable<ConquestMapExcelT>()
+                .Where(x => x.EventContentId == info.EventContentId
+                    && (x.MapDifficulty == difficulty || x.MapDifficulty == StageDifficulty.None))
+                .Select(x => x.StepIndex)
+                .DefaultIfEmpty(step)
+                .Max();
+
+            if (step < maxStep)
+                info.StepByDifficulty[difficulty] = step + 1;
+        }
+
+        // A 0-probability row always drops, matching the repo-wide 10000-basis convention.
+        public Dictionary<RewardTag, List<ParcelInfo>> RollRewardGroup(long rewardGroupId, List<ParcelResult> into)
+        {
+            var byTag = new Dictionary<RewardTag, List<ParcelInfo>>();
+            if (rewardGroupId == 0)
+                return byTag;
+
+            foreach (var row in _excelService.GetTable<ConquestRewardExcelT>().Where(x => x.GroupId == rewardGroupId))
+            {
+                if (row.RewardProb != 0 && Random.Shared.Next(10000) >= row.RewardProb)
+                    continue;
+
+                into.Add(new ParcelResult(row.RewardParcelType, row.RewardId, row.RewardAmount));
+
+                if (!byTag.TryGetValue(row.RewardTag, out var list))
+                    byTag[row.RewardTag] = list = [];
+                list.Add(new ParcelInfo
+                {
+                    Key = new ParcelKeyPair { Type = row.RewardParcelType, Id = row.RewardId },
+                    Amount = row.RewardAmount
+                });
+            }
+
+            return byTag;
+        }
+
+        public ConquestStageSaveDB OpenTileBattle(
+            SchaleDataContext db, AccountDBServer account, ConquestInfoDBServer info,
+            StageDifficulty difficulty, long tileUniqueId, ConquestTileType tileType)
+        {
+            var save = new ConquestStageSaveDB
+            {
+                AccountServerId = account.ServerId,
+                CreateTime = account.GameSettings.ServerDateTime(),
+                EventContentId = info.EventContentId,
+                Difficulty = difficulty,
+                TileUniqueId = tileUniqueId,
+                ConquestTileType = tileType
+            };
+
+            info.OpenBattle = save;
+            db.ConquestInfos.Update(info);
+            db.SaveChanges();
+
+            return save;
+        }
+
+        public void RequireAndClearOpenBattle(
+            SchaleDataContext db, ConquestInfoDBServer info, StageDifficulty difficulty, long tileUniqueId)
+        {
+            var open = info.OpenBattle;
+            info.OpenBattle = null;
+            db.ConquestInfos.Update(info);
+
+            if (open == null
+                || open.EventContentId != info.EventContentId
+                || open.Difficulty != difficulty
+                || open.TileUniqueId != tileUniqueId)
+            {
+                db.SaveChanges();
+                throw new WebAPIException(WebAPIErrorCode.ConquestInvalidSaveData,
+                    $"No open battle on tile {tileUniqueId}");
+            }
+        }
+
+        public static bool IsWin(BattleSummary? summary)
+            => summary != null && !summary.IsAbort && summary.EndType == BattleEndType.Clear;
+
+        // The calculate gauge counts what the event's condition parcel has been spent on.
+        public void TrackConditionSpend(ConquestInfoDBServer info, ParcelType type, long id, long amount)
+        {
+            var calc = _excelService.GetTable<ConquestCalculateExcelT>()
+                .FirstOrDefault(x => x.EventContentId == info.EventContentId);
+            if (calc == null)
+                return;
+            if (calc.CalculateConditionParcelType == type && calc.CalculateConditionParcelUniqueId == id)
+                info.CumulatedConditionValue += amount;
+        }
+    }
+}

--- a/Shittim-Server/Managers/ManagerExtensions.cs
+++ b/Shittim-Server/Managers/ManagerExtensions.cs
@@ -12,6 +12,7 @@ namespace Shittim.Managers
             services.AddSingleton<CampaignManager>();
             services.AddSingleton<CharacterManager>();
             services.AddSingleton<ConcentrateCampaignManager>();
+            services.AddSingleton<ConquestManager>();
             services.AddSingleton<EchelonManager>();
             services.AddSingleton<EliminateRaidManager>();
             services.AddSingleton<EquipmentManager>();

--- a/Shittim-Server/Services/AccountService.cs
+++ b/Shittim-Server/Services/AccountService.cs
@@ -384,6 +384,35 @@ namespace BlueArchiveAPI.Services
         private static ExcelTableService? _excelService;
         private static ParcelHandler? _parcelHandler;
 
+        // Cascade by hand: wipe every child table that carries an AccountServerId column, discovered from the
+        // SQLite catalogue so a new table is never missed. Leaves the Accounts/UserAccounts identity rows alone.
+        public static async Task WipeAccountData(SchaleDataContext context, long accountServerId)
+        {
+            var tables = await context.Database
+                .SqlQueryRaw<string>(
+                    "SELECT m.name AS Value FROM sqlite_master m " +
+                    "JOIN pragma_table_info(m.name) p ON 1=1 " +
+                    "WHERE m.type='table' AND p.name='AccountServerId'")
+                .ToListAsync();
+
+            foreach (var table in tables.Distinct())
+            {
+                if (!IsPlainSqlIdentifier(table))
+                    continue;
+
+                await context.Database.ExecuteSqlRawAsync(
+                    $"DELETE FROM \"{table}\" WHERE AccountServerId = {{0}}", accountServerId);
+            }
+        }
+
+        // SQL identifiers cannot be parameterized, so any name that is interpolated into a statement is required to be a bare identifier first.
+        public static bool IsPlainSqlIdentifier(string name)
+        {
+            return !string.IsNullOrEmpty(name)
+                && (char.IsLetter(name[0]) || name[0] == '_')
+                && name.All(c => char.IsLetterOrDigit(c) || c == '_');
+        }
+
         public static void Initialize(ExcelTableService excelService, ParcelHandler parcelHandler)
         {
             _excelService = excelService;

--- a/Shittim-Server/Services/ConcentrateCampaignManager.cs
+++ b/Shittim-Server/Services/ConcentrateCampaignManager.cs
@@ -26,7 +26,7 @@ public class ConcentrateCampaignManager
     private const long TacticRankClearTimeMsec = 120 * 1000;
 
     // HpInfos is a rate on 0..10000, not absolute hp
-    private const long FullHpRate = 10000L;
+    internal const long FullHpRate = 10000L;
 
     internal const long TacticRankS = 3L;
 
@@ -104,6 +104,122 @@ public class ConcentrateCampaignManager
     // Event runs name their map on the save row because a rerun replays the original event's file; campaign rows leave it null and the stage id is the name.
     internal Task<HexaTileMap> LoadStageMap(CampaignMainStageSaveDBServer save)
         => save.StrategyMap != null ? _hexaMapService.LoadState(save.StrategyMap) : _hexaMapService.LoadState(save.StageUniqueId);
+
+    // The story-strategy (Vol.F) twin of CreateConcentrateCampaign: the map file is named by
+    // StoryStrategyExcel, the save is keyed as StoryStrategyStage, and the table carries no entrance cost.
+    public async Task<CampaignMainStageSaveDBServer> CreateStoryStrategyStage(
+        SchaleDataContext context,
+        AccountDBServer account,
+        long stageUniqueId)
+    {
+        var stageExcel = _excelService.GetTable<StoryStrategyExcelT>().FirstOrDefault(x => x.Id == stageUniqueId)
+            ?? throw new WebAPIException(WebAPIErrorCode.CampaignStageStageNotFound,
+                $"Story strategy stage {stageUniqueId} not found");
+
+        var hexaData = await _hexaMapService.LoadState(stageExcel.StrategyMap);
+
+        await CloseConcentrateCampaigns(context, account);
+
+        var stageSave = new CampaignMainStageSaveDBServer
+        {
+            ContentType = Schale.FlatData.ContentType.StoryStrategyStage,
+            LastEnemyEntityId = hexaData.LastEntityId,
+            EnemyInfos = HexaMapService.AddHexaUnitList(hexaData.HexaUnitList),
+            EchelonInfos = new Dictionary<long, HexaUnit>(),
+            WithdrawInfos = new Dictionary<long, List<long>>(),
+            StrategyObjects = HexaMapService.AddHexaStrategyList(hexaData.HexaStrageyList),
+            StrategyObjectRewards = new Dictionary<long, List<ParcelInfo>>(),
+            StrategyObjectHistory = new List<long>(),
+            ActivatedHexaEventsAndConditions = BuildStartEventActivations(hexaData),
+            HexaEventDelayedExecutions = new Dictionary<long, List<long>>(),
+            TileMapStates = HexaMapService.AddHexaTileList(hexaData),
+            DisplayInfos = new List<HexaDisplayInfo>(),
+            DeployedEchelonInfos = new List<HexaUnit>(),
+            StrategyMap = stageExcel.StrategyMap,
+            CreateTime = account.GameSettings.ServerDateTime(),
+            StageUniqueId = stageUniqueId,
+            StageEntranceFee = new List<ParcelInfo>(),
+            EnemyKillCountByUniqueId = new(),
+            IsOpen = true
+        };
+        stageSave.AccountServerId = account.ServerId;
+
+        context.CampaignMainStageSaves.Add(stageSave);
+        await context.SaveChangesAsync();
+
+        return stageSave;
+    }
+
+    // Story tactics carry no stage history, stars, rewards, or missions - the story flow only needs the
+    // map state advanced and the win/lose verdict; everything else in TacticResult is campaign bookkeeping.
+    public async Task<(CampaignMainStageSaveDBServer Save, bool IsPlayerWin)> ScenarioTacticResult(
+        SchaleDataContext context,
+        AccountDBServer account,
+        CampaignTacticResultRequest req)
+    {
+        if (req.Summary == null)
+            throw new InvalidOperationException("Scenario_TacticResult carried no battle summary");
+
+        var stageSaveData = await GetConcentrateCampaign(context, account, req.Summary.StageId)
+            ?? throw new InvalidOperationException($"Story stage save not found for stage {req.Summary.StageId}");
+
+        stageSaveData.TacticClearTimeMscSum += (long)Math.Floor(req.Summary.EndFrame / 30f) * 1000;
+        stageSaveData.EchelonInfos = ChangeConcentratedEchelon(stageSaveData.EchelonInfos, req.Summary, req.Hand);
+
+        var engagedEnemyId = stageSaveData.EngagedEnemyEntityId;
+        var wasEnemyPhase = stageSaveData.CampaignState == CampaignState.EnemyPhase;
+        var isStageClear = false;
+        var tacticWon = CheckIfCleared(req.Summary);
+
+        if (!tacticWon)
+        {
+            stageSaveData.EchelonInfos?.Remove(req.Summary.Group01Summary.TeamId);
+        }
+        else
+        {
+            if (stageSaveData.EnemyInfos != null &&
+                stageSaveData.EnemyInfos.Remove(stageSaveData.EngagedEnemyEntityId))
+            {
+                stageSaveData.EnemyClearCount++;
+            }
+
+            stageSaveData.EngagedEnemyEntityId = 0;
+
+            var hexaData = await LoadStageMap(stageSaveData);
+            var endBattle = HexaMapService.FindSatisfiedEndBattle(
+                hexaData, stageSaveData.EnemyInfos, stageSaveData.ActivatedHexaEventsAndConditions);
+
+            if (endBattle is { } fired)
+            {
+                stageSaveData.ActivatedHexaEventsAndConditions ??= new Dictionary<long, List<long>>();
+                stageSaveData.ActivatedHexaEventsAndConditions[fired.Event.EventId] = fired.ConditionIds;
+                isStageClear = true;
+            }
+            else if (stageSaveData.EnemyInfos is { Count: 0 })
+            {
+                isStageClear = true;
+            }
+
+            if (isStageClear)
+                stageSaveData.IsOpen = false;
+        }
+
+        if (wasEnemyPhase && !isStageClear)
+        {
+            DecideEnemyMoves(
+                await LoadStageMap(stageSaveData), stageSaveData, engagedEnemyId,
+                _excelService.GetTable<CampaignUnitExcelT>(), _excelService.GetTable<CampaignStrategyObjectExcelT>());
+        }
+        else
+        {
+            stageSaveData.DisplayInfos = new List<HexaDisplayInfo>();
+        }
+
+        context.CampaignMainStageSaves.Update(stageSaveData);
+        await context.SaveChangesAsync();
+
+        return (stageSaveData, tacticWon);
+    }
 
     public async Task<CampaignMainStageSaveDBServer> CreateConcentrateCampaign(
         SchaleDataContext context,

--- a/Shittim-Server/Services/ConsumeHandler.cs
+++ b/Shittim-Server/Services/ConsumeHandler.cs
@@ -112,7 +112,9 @@ public class ConsumeResolver
 
     public void HandleEquipmentConsumption(ConsumeRequestDB consumeRequest)
     {
-        foreach (var consumeData in consumeRequest.ConsumeEquipmentServerIdAndCounts)
+        // The model declares this nullable and the client omits the kinds it is not consuming; iterating it raw
+        // turned every such request into a 500.
+        foreach (var consumeData in consumeRequest.ConsumeEquipmentServerIdAndCounts ?? [])
         {
             var equipment = Context.Equipments.FirstOrDefault(x => x.AccountServerId == Account.ServerId && x.ServerId == consumeData.Key);
             if (equipment == null) continue;
@@ -144,7 +146,9 @@ public class ConsumeResolver
 
     public void HandleFurnitureConsumption(ConsumeRequestDB consumeRequest)
     {
-        foreach (var consumeData in consumeRequest.ConsumeFurnitureServerIdAndCounts)
+        // The model declares this nullable and the client omits the kinds it is not consuming; iterating it raw
+        // turned every such request into a 500.
+        foreach (var consumeData in consumeRequest.ConsumeFurnitureServerIdAndCounts ?? [])
         {
             var furniture = Context.Furnitures.FirstOrDefault(x => x.AccountServerId == Account.ServerId && x.ServerId == consumeData.Key);
             if (furniture == null) continue;
@@ -176,7 +180,9 @@ public class ConsumeResolver
 
     public void HandleItemConsumption(ConsumeRequestDB consumeRequest)
     {
-        foreach (var consumeData in consumeRequest.ConsumeItemServerIdAndCounts)
+        // The model declares this nullable and the client omits the kinds it is not consuming; iterating it raw
+        // turned every such request into a 500.
+        foreach (var consumeData in consumeRequest.ConsumeItemServerIdAndCounts ?? [])
         {
             var item = Context.Items.FirstOrDefault(x => x.AccountServerId == Account.ServerId && x.ServerId == consumeData.Key);
             if (item == null) continue;

--- a/Shittim-Server/Services/EchelonService.cs
+++ b/Shittim-Server/Services/EchelonService.cs
@@ -37,14 +37,23 @@ public class EchelonService
     }
 
     public static async Task<EchelonDBServer?> GetConcentratedCampaignEchelon(
-        SchaleDataContext context, 
-        long accountId, 
+        SchaleDataContext context,
+        long accountId,
         long echelonNum)
     {
+        // Story strategy stages (Vol.F) save their formations under their own echelon type; every other
+        // strategy-map deploy uses Adventure, so that stays the first match.
         return await context.Echelons
             .FirstOrDefaultAsync(e =>
                 e.AccountServerId == accountId &&
                 e.EchelonType == EchelonType.Adventure &&
+                e.EchelonNumber == echelonNum &&
+                e.ExtensionType == EchelonExtensionType.Base
+            )
+            ?? await context.Echelons
+            .FirstOrDefaultAsync(e =>
+                e.AccountServerId == accountId &&
+                e.EchelonType == EchelonType.StoryStrategyStage &&
                 e.EchelonNumber == echelonNum &&
                 e.ExtensionType == EchelonExtensionType.Base
             );

--- a/Shittim-Server/Services/EliminateRaidManager.cs
+++ b/Shittim-Server/Services/EliminateRaidManager.cs
@@ -87,7 +87,7 @@ public class EliminateRaidManager
                 SeasonId = account.ContentInfo.EliminateRaidDataInfo.SeasonId,
                 BestRankingPoint = account.ContentInfo.EliminateRaidDataInfo.BestRankingPoint,
                 TotalRankingPoint = account.ContentInfo.EliminateRaidDataInfo.TotalRankingPoint,
-                ReceiveRewardIds = targetSeason.SeasonRewardId,
+                ReceiveRewardIds = [],
                 PlayableHighestDifficulty = new()
                 {
                     { targetSeason.OpenRaidBossGroup01, Difficulty.Lunatic },
@@ -134,7 +134,9 @@ public class EliminateRaidManager
                 raidLobby.NextSeasonStartDate = serverTime.AddMonths(1);
                 raidLobby.NextSeasonEndDate = serverTime.AddMonths(1).AddDays(7);
                 raidLobby.NextSettlementEndDate = serverTime.AddMonths(1).AddDays(8);
-                raidLobby.ReceiveRewardIds = targetSeason.SeasonRewardId;
+                raidLobby.ReceiveRewardIds = [];
+                raidLobby.ReceiveLimitedRewardIds = [];
+                raidLobby.ReceivedRankingRewardId = 0;
                 raidLobby.PlayableHighestDifficulty = new()
                 {
                     { targetSeason.OpenRaidBossGroup01, Difficulty.Lunatic },
@@ -171,6 +173,7 @@ public class EliminateRaidManager
             foreach (var group in raidLobby.OpenedBossGroups)
                 raidLobby.BestRankingPointPerBossGroup.TryAdd(group, 0);
         }
+        raidLobby.CanReceiveRankingReward = raidLobby.ReceivedRankingRewardId == 0 && raidLobby.TotalRankingPoint > 0;
         await context.SaveChangesAsync();
         
         return raidLobby;

--- a/Shittim-Server/Services/MomoTalkService.cs
+++ b/Shittim-Server/Services/MomoTalkService.cs
@@ -1,4 +1,6 @@
+using Schale.Data;
 using Schale.Data.GameModel;
+using Schale.FlatData;
 
 namespace BlueArchiveAPI.Services
 {
@@ -12,6 +14,111 @@ namespace BlueArchiveAPI.Services
                 favorSchedules[outline.CharacterId] = outline.ScheduleIds;
             }
             return favorSchedules;
+        }
+
+        /// <summary>
+        /// The group a student's MomoTalk opens on, or 0 while their first conversation is still rank-locked.
+        /// AcademyMessangerExcel numbers a student's groups in reading order and only the opening one has nothing
+        /// pointing at it, so the lowest id is the entry point; it carries the FavorRankUp condition that unlocks it
+        /// (true for 255 of the 256 students in the live table).
+        /// </summary>
+        public static long OpeningGroup(
+            List<AcademyMessangerExcelT> messengers, long characterId, long favorRank)
+        {
+            var opening = messengers
+                .Where(x => x.CharacterId == characterId)
+                .GroupBy(x => x.MessageGroupId)
+                .OrderBy(g => g.Key)
+                .FirstOrDefault();
+
+            if (opening == null || !IsUnlocked(opening, favorRank))
+                return 0;
+
+            return opening.Key;
+        }
+
+        /// <summary>
+        /// The group after <paramref name="currentGroupId"/> when it is a conversation that a rank-up has just
+        /// opened, otherwise 0. Ordinary continuations are excluded on purpose: the client walks those itself
+        /// through MomoTalk_Read, and pushing them here would spill a conversation the player has not read yet.
+        /// </summary>
+        public static long RankUnlockedGroup(
+            List<AcademyMessangerExcelT> messengers, long currentGroupId, long favorRank)
+        {
+            var nextGroupId = messengers
+                .Where(x => x.MessageGroupId == currentGroupId && x.NextGroupId > 0 && x.NextGroupId != currentGroupId)
+                .Select(x => x.NextGroupId)
+                .FirstOrDefault();
+
+            if (nextGroupId == 0)
+                return 0;
+
+            var next = messengers.Where(x => x.MessageGroupId == nextGroupId).ToList();
+            if (next.Count == 0)
+                return 0;
+
+            var opening = next.OrderBy(x => x.Id).First();
+            if (opening.MessageCondition != AcademyMessageConditions.FavorRankUp
+                || favorRank < opening.ConditionValue)
+            {
+                return 0;
+            }
+
+            return nextGroupId;
+        }
+
+        /// <summary>
+        /// Gives every owned student the outline row the MomoTalk list renders from, and moves a student whose
+        /// conversation stopped at a FavorRankUp gate onto the conversation that rank has since opened. Without this
+        /// a fresh account has no rows at all, so no conversation can be started, and a conversation that ran into a
+        /// gate never resumes - the client has no reason to send another MomoTalk_Read for a group it already read.
+        /// The rows are added to the context but not saved - the caller's SaveChangesAsync commits them.
+        /// </summary>
+        public static void SyncOutlines(
+            SchaleDataContext context, AccountDBServer account, List<AcademyMessangerExcelT> messengers)
+        {
+            var outlinesByCharacterDbId = context.GetAccountMomoTalkOutLines(account.ServerId)
+                .ToList()
+                .ToDictionary(x => x.CharacterDBId);
+
+            var now = account.GameSettings.ServerDateTime();
+
+            foreach (var character in context.Characters
+                         .Where(x => x.AccountServerId == account.ServerId).ToList())
+            {
+                if (outlinesByCharacterDbId.TryGetValue(character.ServerId, out var outline))
+                {
+                    var unlocked = RankUnlockedGroup(
+                        messengers, outline.LatestMessageGroupId, character.FavorRank);
+                    if (unlocked == 0)
+                        continue;
+
+                    outline.LatestMessageGroupId = unlocked;
+                    outline.ChosenMessageId = null;
+                    outline.LastUpdateDate = now;
+                    continue;
+                }
+
+                var opening = OpeningGroup(messengers, character.UniqueId, character.FavorRank);
+                if (opening == 0)
+                    continue;
+
+                context.MomoTalkOutLines.Add(new MomoTalkOutLineDBServer
+                {
+                    AccountServerId = account.ServerId,
+                    CharacterDBId = character.ServerId,
+                    CharacterId = character.UniqueId,
+                    LatestMessageGroupId = opening,
+                    LastUpdateDate = now
+                });
+            }
+        }
+
+        private static bool IsUnlocked(IEnumerable<AcademyMessangerExcelT> group, long favorRank)
+        {
+            var opening = group.OrderBy(x => x.Id).First();
+            return opening.MessageCondition != AcademyMessageConditions.FavorRankUp
+                || favorRank >= opening.ConditionValue;
         }
     }
 }

--- a/Shittim-Server/Services/MomoTalkService.cs
+++ b/Shittim-Server/Services/MomoTalkService.cs
@@ -77,9 +77,12 @@ namespace BlueArchiveAPI.Services
         public static void SyncOutlines(
             SchaleDataContext context, AccountDBServer account, List<AcademyMessangerExcelT> messengers)
         {
+            // Grouped rather than keyed directly: a duplicate row from older data would throw out of ToDictionary,
+            // and this runs on the login path where that would cost the account its session rather than a conversation.
             var outlinesByCharacterDbId = context.GetAccountMomoTalkOutLines(account.ServerId)
                 .ToList()
-                .ToDictionary(x => x.CharacterDBId);
+                .GroupBy(x => x.CharacterDBId)
+                .ToDictionary(g => g.Key, g => g.First());
 
             var now = account.GameSettings.ServerDateTime();
 

--- a/Shittim-Server/Services/MomoTalkService.cs
+++ b/Shittim-Server/Services/MomoTalkService.cs
@@ -68,6 +68,42 @@ namespace BlueArchiveAPI.Services
         }
 
         /// <summary>
+        /// Where an existing outline should resume, or 0 to leave it. A pending gate recorded by MomoTalk_Read is
+        /// authoritative: it opens once the rank is reached. Rows without one predate the marker, and there
+        /// LatestMessageGroupId cannot distinguish "read and stopped at the next group's gate" from "next unread
+        /// group" - advancing an unread group skips its story - so those only move when a recorded choice proves
+        /// the current group was read.
+        /// </summary>
+        public static long ResumeGroup(
+            List<AcademyMessangerExcelT> messengers,
+            long currentGroupId,
+            long? pendingGateGroupId,
+            bool currentGroupWasRead,
+            long favorRank)
+        {
+            if (pendingGateGroupId is > 0)
+            {
+                var opening = messengers
+                    .Where(x => x.MessageGroupId == pendingGateGroupId)
+                    .OrderBy(x => x.Id)
+                    .FirstOrDefault();
+                if (opening == null)
+                    return 0;
+                if (opening.MessageCondition == AcademyMessageConditions.FavorRankUp
+                    && favorRank < opening.ConditionValue)
+                {
+                    return 0;
+                }
+                return pendingGateGroupId.Value;
+            }
+
+            if (!currentGroupWasRead)
+                return 0;
+
+            return RankUnlockedGroup(messengers, currentGroupId, favorRank);
+        }
+
+        /// <summary>
         /// Gives every owned student the outline row the MomoTalk list renders from, and moves a student whose
         /// conversation stopped at a FavorRankUp gate onto the conversation that rank has since opened. Without this
         /// a fresh account has no rows at all, so no conversation can be started, and a conversation that ran into a
@@ -86,17 +122,28 @@ namespace BlueArchiveAPI.Services
 
             var now = account.GameSettings.ServerDateTime();
 
+            var readGroups = context.GetAccountMomoTalkChoices(account.ServerId)
+                .Select(c => new { c.CharacterDBId, c.MessageGroupId })
+                .ToList()
+                .Select(c => (c.CharacterDBId, c.MessageGroupId))
+                .ToHashSet();
+
             foreach (var character in context.Characters
                          .Where(x => x.AccountServerId == account.ServerId).ToList())
             {
                 if (outlinesByCharacterDbId.TryGetValue(character.ServerId, out var outline))
                 {
-                    var unlocked = RankUnlockedGroup(
-                        messengers, outline.LatestMessageGroupId, character.FavorRank);
-                    if (unlocked == 0)
+                    var resume = ResumeGroup(
+                        messengers,
+                        outline.LatestMessageGroupId,
+                        outline.PendingGateGroupId,
+                        readGroups.Contains((outline.CharacterDBId, outline.LatestMessageGroupId)),
+                        character.FavorRank);
+                    if (resume == 0)
                         continue;
 
-                    outline.LatestMessageGroupId = unlocked;
+                    outline.LatestMessageGroupId = resume;
+                    outline.PendingGateGroupId = null;
                     outline.ChosenMessageId = null;
                     outline.LastUpdateDate = now;
                     continue;

--- a/Shittim-Server/Services/ParcelHandler.cs
+++ b/Shittim-Server/Services/ParcelHandler.cs
@@ -48,6 +48,8 @@ public class ParcelHandler
         _academyLocationExpData = new ExpLevelData().ConvertExpLevelData(academyLocationLevelExcel);
     }
 
+    // Commits its own transaction, so anything that must not outlive a failed grant - a claimed-marker, a
+    // consumed flag - has to be written and Update()d before the call, not after it.
     public async Task<ParcelResolver> BuildParcel(
         SchaleDataContext context,
         AccountDBServer account,

--- a/Shittim-Server/Services/RaidManager.cs
+++ b/Shittim-Server/Services/RaidManager.cs
@@ -87,7 +87,7 @@ public class RaidManager
                 SeasonId = account.ContentInfo.RaidDataInfo.SeasonId,
                 BestRankingPoint = account.ContentInfo.RaidDataInfo.BestRankingPoint,
                 TotalRankingPoint = account.ContentInfo.RaidDataInfo.TotalRankingPoint,
-                ReceiveRewardIds = targetSeason.SeasonRewardId,
+                ReceiveRewardIds = [],
                 PlayableHighestDifficulty = new Dictionary<string, Difficulty>()
                 {
                     { targetSeason.OpenRaidBossGroup.FirstOrDefault(), Difficulty.Lunatic }
@@ -120,7 +120,9 @@ public class RaidManager
                 raidLobby.NextSeasonStartDate = serverTime.AddMonths(1);
                 raidLobby.NextSeasonEndDate = serverTime.AddMonths(1).AddDays(7);
                 raidLobby.NextSettlementEndDate = serverTime.AddMonths(1).AddDays(8);
-                raidLobby.ReceiveRewardIds = targetSeason.SeasonRewardId;
+                raidLobby.ReceiveRewardIds = [];
+                raidLobby.ReceiveLimitedRewardIds = [];
+                raidLobby.ReceivedRankingRewardId = 0;
                 raidLobby.PlayableHighestDifficulty = new Dictionary<string, Difficulty>()
                 {
                     { targetSeason.OpenRaidBossGroup.FirstOrDefault(), Difficulty.Lunatic }
@@ -129,6 +131,7 @@ public class RaidManager
             raidLobby.BestRankingPoint = account.ContentInfo.RaidDataInfo.BestRankingPoint;
             raidLobby.TotalRankingPoint = account.ContentInfo.RaidDataInfo.TotalRankingPoint;
         }
+        raidLobby.CanReceiveRankingReward = raidLobby.ReceivedRankingRewardId == 0 && raidLobby.TotalRankingPoint > 0;
         await context.SaveChangesAsync();
         return raidLobby;
     }

--- a/Shittim-Server/Services/RaidService.cs
+++ b/Shittim-Server/Services/RaidService.cs
@@ -1,10 +1,14 @@
 using Schale.Data;
 using Schale.Data.GameModel;
 using Schale.FlatData;
+using Schale.MX.Core.Math;
 using Schale.MX.GameLogic.DBModel;
+using Schale.MX.GameLogic.Parcel;
 using Schale.MX.Logic.Battles.Summary;
 using Schale.MX.Logic.Data;
 using Schale.MX.NetworkProtocol;
+using Shittim.Services;
+using Shittim_Server.Core.NetworkProtocol.Handlers;
 
 namespace Shittim_Server.Services;
 
@@ -205,6 +209,80 @@ public static class RaidService
         raidLobby.PlayingRaidDB.RaidBossDBs = raid.RaidBossDBs;
     }
 
+    public static List<ParcelResult> RollStageRewards(IEnumerable<RaidStageRewardExcelT> rows) =>
+        rows.Where(x => MathService.GenerateProbability(x.ClearStageRewardProb))
+            .Select(x => new ParcelResult(x.ClearStageRewardParcelType, x.ClearStageRewardParcelUniqueID, x.ClearStageRewardAmount))
+            .ToList();
+
+    public static List<ParcelResult> RollStageRewards(IEnumerable<EliminateRaidStageRewardExcelT> rows) =>
+        rows.Where(x => MathService.GenerateProbability(x.ClearStageRewardProb))
+            .Select(x => new ParcelResult(x.ClearStageRewardParcelType, x.ClearStageRewardParcelUniqueID, x.ClearStageRewardAmount))
+            .ToList();
+
+    public static List<ParcelInfo> ToParcelInfos(List<ParcelResult> parcels) =>
+        parcels.Select(r => new ParcelInfo
+        {
+            Key = new ParcelKeyPair { Type = r.Type, Id = r.Id },
+            Amount = r.Amount,
+            Multiplier = BasisPoint.One,
+            Probability = BasisPoint.One
+        }).ToList();
+
+    public static List<ParcelResult> ZipParcelColumns(List<ParcelType>? types, List<long>? ids, List<long>? amounts)
+    {
+        var count = ShopHandler.AlignedColumnCount(types?.Count, ids?.Count, amounts?.Count);
+        var parcels = new List<ParcelResult>(count);
+        for (int i = 0; i < count; i++)
+            parcels.Add(new ParcelResult(types![i], ids![i], amounts![i]));
+        return parcels;
+    }
+
+    public static List<long> ClaimableSeasonRewardIds(
+        List<long>? rewardIds, List<long>? thresholds, long gauge, ICollection<long> received)
+    {
+        var count = Math.Min(rewardIds?.Count ?? 0, thresholds?.Count ?? 0);
+        var claimable = new List<long>();
+        for (int i = 0; i < count; i++)
+        {
+            if (thresholds![i] <= gauge && !received.Contains(rewardIds![i]))
+                claimable.Add(rewardIds[i]);
+        }
+        return claimable;
+    }
+
+    // Characters were stored heroes-then-supporters (CollectAllCharacters), so the first four are the main slots.
+    public static List<RaidTeamSettingDB> BuildBestTeams(
+        SchaleDataContext context, RaidSummaryDB summary, long accountId, EchelonType echelonType)
+    {
+        var teams = new List<RaidTeamSettingDB>();
+        foreach (var battleId in summary.BattleSummaryIds)
+        {
+            var battle = context.BattleSummaries.FirstOrDefault(x => x.BattleId == battleId);
+            if (battle == null) continue;
+
+            var characters = battle.Characters.Select((c, i) => new RaidCharacterDB
+            {
+                ServerId = c.CharacterDBId,
+                UniqueId = c.UniqueId,
+                StarGrade = c.StarGrade,
+                Level = c.Level,
+                SlotIndex = i,
+                AccountId = accountId
+            }).ToList();
+
+            teams.Add(new RaidTeamSettingDB
+            {
+                AccountId = accountId,
+                TryNumber = teams.Count,
+                EchelonType = echelonType,
+                MainCharacterDBs = characters.Take(4).ToList(),
+                SupportCharacterDBs = characters.Skip(4).ToList(),
+                LeaderCharacterUniqueId = characters.FirstOrDefault()?.UniqueId ?? 0
+            });
+        }
+        return teams;
+    }
+
     public static long AIPhaseCheck(
         int bossIndex,
         long bossHp,
@@ -292,4 +370,9 @@ public static class RaidService
 
         return 0;
     }
+
+    // A raid row exists from the moment its battle is created, and EndBossBattle writes Clear even for a
+    // give-up, so "was it actually beaten" has to be read off the bosses.
+    public static bool IsCleared(Schale.Data.GameModel.RaidDBServer raid)
+        => raid.RaidBossDBs is { Count: > 0 } bosses && bosses.All(b => b.BossCurrentHP <= 0);
 }

--- a/Shittim-Server/Services/ResetableContentService.cs
+++ b/Shittim-Server/Services/ResetableContentService.cs
@@ -1,0 +1,48 @@
+using BlueArchiveAPI.Configuration;
+using Schale.Data.GameModel;
+using Schale.FlatData;
+using Schale.MX.GameLogic.DBModel;
+
+namespace Shittim_Server.Services;
+
+// Counters the game resets on a cycle - hard-stage play purchases, strategy-map heals. Official resets them
+// daily; here a counter resets by ageing out of ResetableContentResetDays.
+// The values live in the account's GameSettings JSON column, so every caller has to follow a mutation with
+// db.Accounts.Update(account) - EF does not see changes made inside the column.
+public static class ResetableContentService
+{
+    public static TimeSpan ResetWindow =>
+        TimeSpan.FromDays(Config.Instance.ServerConfiguration.ResetableContentResetDays);
+
+    public static List<ResetableContentValueDB> LiveValues(AccountDBServer account, TimeSpan window)
+    {
+        var now = account.GameSettings.ServerDateTime();
+        account.GameSettings.ResetableContents.RemoveAll(x => now - x.LastUpdateTime >= window);
+        return account.GameSettings.ResetableContents;
+    }
+
+    public static long LiveValue(AccountDBServer account, ResetContentType type, long mapped, TimeSpan window)
+    {
+        return LiveValues(account, window)
+            .FirstOrDefault(x => x.ResetableContentId.Type == type && x.ResetableContentId.Mapped == mapped)
+            ?.ContentValue ?? 0;
+    }
+
+    public static long Bump(AccountDBServer account, ResetContentType type, long mapped, TimeSpan window, long delta = 1)
+    {
+        var live = LiveValues(account, window);
+        var entry = live.FirstOrDefault(x => x.ResetableContentId.Type == type && x.ResetableContentId.Mapped == mapped);
+        if (entry == null)
+        {
+            entry = new ResetableContentValueDB
+            {
+                ResetableContentId = new ResetableContentId { Type = type, Mapped = mapped }
+            };
+            live.Add(entry);
+        }
+
+        entry.ContentValue += delta;
+        entry.LastUpdateTime = account.GameSettings.ServerDateTime();
+        return entry.ContentValue;
+    }
+}

--- a/Shittim-Server/Services/SessionKeyService.cs
+++ b/Shittim-Server/Services/SessionKeyService.cs
@@ -22,6 +22,7 @@ namespace BlueArchiveAPI.Services
             Protocol.Queuing_ProcessWaitingQueue,
             Protocol.Account_CheckYostar,
             Protocol.Account_CheckNexon,
+            Protocol.Account_PassCheck,
             Protocol.Account_Auth,
             Protocol.Account_Create,
             Protocol.ProofToken_RequestQuestion

--- a/ShittimControlCenter/src/js/pages/overview.js
+++ b/ShittimControlCenter/src/js/pages/overview.js
@@ -46,7 +46,7 @@ export default {
     const offlineCard = cardWith('Offline mode', 'No route out, no name server', [],
       el('div', {},
         el('div.row.wrap', { style: { gap: '10px', minWidth: '0' } }, offlineBtn, hostsBtn),
-        el('p', { text: 'Brings the server and the proxy up with their offline switches on and points every host the client contacts at loopback, so nothing it asks for needs a name server or a route out. Steam still has to be running - offline mode is fine, but the client reads the SDK version back before it will boot at all.', style: { fontSize: '12.5px', color: 'var(--ink-3)', margin: '12px 0 0', lineHeight: '1.6' } }),
+        el('p', { text: 'Brings the server and the proxy up with their offline switches on and points every host the client contacts at loopback, so nothing it asks for needs a name server or a route out. Steam still has to be running - its own Offline Mode is fine, but the client reads the SDK version back before it will boot at all. Leave the network adapter up: the offline patch bypasses the Steam calls made after the SDK starts, not the SDK start itself, so pulling the cable or switching wifi off fails at boot with "Failed to connect to the network" no matter what the patch log says.', style: { fontSize: '12.5px', color: 'var(--ink-3)', margin: '12px 0 0', lineHeight: '1.6' } }),
         hostsLine));
 
     const exportBtn = button('Export logs', { variant: 'ghost', iconName: 'save', onClick: async () => {


### PR DESCRIPTION
## Summary

The client declares 501 protocols. The coverage report flagged the ones that have wire models but no handler — the server answered ErrorCode 500 and the client showed the generic failure popup. **This branch implements every one of them.**

On the count: the report's headline says 216, but its own data contains exactly **214** such protocols (the two extra are a bug in the report's tally, not two missing protocols). Of those 214, **77 had already been implemented** in earlier work that this branch is stacked on; the remaining **137 land here, one protocol per commit**.

### New subsystems

- **Resetable content** — counters (hard-stage play purchases, strategy-map heals) live in the account's GameSettings and reset by ageing out of a configurable window: `ResetableContentResetDays`, **default 60 days** (official resets daily; the long default is deliberate for a single-player server).
- **Conquest** — one row per account and event holding tile, echelon and step state as wire-shaped JSON. Free tiles conquer directly, battle tiles pair start→result, steps open when their playable tiles are taken, bases produce and upgrade, and the calculate gauge pays per threshold.
- **Clan** — clan membership in GameSettings. Everyone starts in the stock Arona club; you can quit it, search for it, rejoin, or create your own and become president.
- **Story strategy (Vol.F)** — the Scenario main-stage flow runs on the existing campaign hex-map machine, the same way the event twin does.
- **Shifting craft** — a table for the craft slots behind the five Shifting protocols and the three batch node-craft variants.
- **Raid / EliminateRaid rewards** — shared roll, season-gauge and best-team helpers; a claimed flag on the raid row.

Multiplayer-facing protocols are emulated for a single-player server (own-account mirrors, offline opponents and decks), following the `ArenaService.CreateOpponents` precedent already in the repo.

### Commit layout

11 infrastructure commits (wire fields, per-account state, storage, managers, services, handler scaffolding), then **137 commits of one protocol each**, then the behaviour tests. Every commit in the range was built; the tree at the tip is byte-identical to the reviewed single-branch version.

### Self-review

An adversarial review of this branch found and this branch fixes: a free unlimited `Raid_Sweep`, `Raid_Reward` paying for raids that were never beaten, reward claims that committed the grant before the claimed-marker (replayable on failure), an unbounded `Conquest_ManageBase` count, shifting-craft consume counts trusted without checking the stack and a gold cost clamped instead of refused, six sites sending a Characters row id where the wire wants a character UniqueId, and two lock handlers turning a stale id into a 500.

## Known gaps (TODO)

Both were researched to a definite answer rather than left as guesses.

**1. `Item_Sell` / `Equipment_Sell` credit no currency.**
A reflection sweep over all 486 shipped `*ExcelT` types — 408 ExcelDB tables plus the `.bytes` tables — found no per-item or per-rarity gold value. The only `Price` fields are real-money IAP prices; the only `Gold` fields are craft *inputs*; there are zero hits for disassemble, dismantle, salvage or buyback. The handlers validate ownership, refuse locked and equipped rows, delete them, and return the unchanged wallet.

Both sell responses carry `AccountCurrencyDB` and nothing else — a shape unique among all 499 protocols — which says the live server did credit something, from a table that never shipped to the client.

> **TODO:** credit gold here if a per-item or per-rarity value ever surfaces. Do **not** derive one from the item→currency `GoodsExcel` rows: those are event-shop coin exchanges keyed by `GoodsId`, covering 8% of items, no equipment at all, and 46 of them pay Gems.

**2. Conquest never spawns event objects (treasure boxes, unexpected enemies, erosion).**
The five object handlers answer `ConquestObjectNotFound` instead of a 500. The excel data is complete — `ConquestObjectExcel` (StepIndex, StepObjectCount, Disposable, reward), `ConquestErosionExcel` (phases, start conditions, battle-entry cost) and the tile's `MassErosionId` are all populated.

The blocker is `TypedJsonWrapper<T>` (`Schale/MX/Core/Services/Services.cs`): its implicit operator discards the object it is handed and leaves `JsonWithType` empty, and every conquest response ships its objects through that wrapper. A spawner written today would persist rows the client could never receive.

> **TODO:** implement the wrapper first. It needs the client's exact `$type` token, which no capture available here pins down, so it wants a real `Conquest_GetInfo` capture from an event with objects on the map. Once that exists the spawner is fully specified by the data. Related gap: `AlertMassErosionId` is on the wire `ConquestInfoDB` but on neither the server entity nor `ToInfoDB`.

## Test evidence

- `dotnet test`: **467 passed, 0 failed, 0 skipped**
- 137 new `ProtocolRegistrationTests` assertions, one per implemented protocol
- New behaviour tests: `ResetableContentWindowTests`, `ItemLockPersistenceTests`, `RaidClearGateTests`, `RaidRewardHelperTests`, `ShiftingCraftTests`

Stacked on #33.
