### PR TITLE
Account import: restore the full account, and import from the Control Center

### DIFF
--- a/Schale/MappingProfiles/Mapping.cs
+++ b/Schale/MappingProfiles/Mapping.cs
@@ -149,15 +149,13 @@ namespace Schale.MappingProfiles
             CreateMap<StickerDB, StickerDBServer>();
             CreateMap<AccountAttachmentDB, AccountAttachmentDBServer>();
 
-            // Progression. Only the export direction existed, so accountdata load had no way
-            // to restore story or campaign history even though ExportData writes both.
+            // Import direction for the rows accountdata load restores.
             CreateMap<ScenarioHistoryDB, ScenarioHistoryDBServer>();
             CreateMap<ScenarioGroupHistoryDB, ScenarioGroupHistoryDBServer>();
             CreateMap<CampaignStageHistoryDB, CampaignStageHistoryDBServer>();
             CreateMap<CampaignChapterClearRewardHistoryDB, CampaignChapterClearRewardHistoryDBServer>();
             CreateMap<StrategyObjectHistoryDB, StrategyObjectHistoryDBServer>();
 
-            // Collections restored by accountdata load; export-direction only until now.
             CreateMap<MomoTalkOutLineDB, MomoTalkOutLineDBServer>();
             CreateMap<EventContentPermanentDB, EventContentPermanentDBServer>();
             CreateMap<StickerBookDB, StickerBookDBServer>();

--- a/Schale/MappingProfiles/Mapping.cs
+++ b/Schale/MappingProfiles/Mapping.cs
@@ -161,6 +161,8 @@ namespace Schale.MappingProfiles
             CreateMap<MomoTalkOutLineDB, MomoTalkOutLineDBServer>();
             CreateMap<EventContentPermanentDB, EventContentPermanentDBServer>();
             CreateMap<StickerBookDB, StickerBookDBServer>();
+            CreateMap<ShopFreeRecruitHistoryDB, ShopFreeRecruitHistoryDBServer>();
+            CreateMap<CraftInfoDB, CraftInfoDBServer>();
         }
 
         private void ConfigureNestedDTOMappings()

--- a/Schale/MappingProfiles/Mapping.cs
+++ b/Schale/MappingProfiles/Mapping.cs
@@ -156,6 +156,11 @@ namespace Schale.MappingProfiles
             CreateMap<CampaignStageHistoryDB, CampaignStageHistoryDBServer>();
             CreateMap<CampaignChapterClearRewardHistoryDB, CampaignChapterClearRewardHistoryDBServer>();
             CreateMap<StrategyObjectHistoryDB, StrategyObjectHistoryDBServer>();
+
+            // Collections restored by accountdata load; export-direction only until now.
+            CreateMap<MomoTalkOutLineDB, MomoTalkOutLineDBServer>();
+            CreateMap<EventContentPermanentDB, EventContentPermanentDBServer>();
+            CreateMap<StickerBookDB, StickerBookDBServer>();
         }
 
         private void ConfigureNestedDTOMappings()

--- a/Schale/MappingProfiles/Mapping.cs
+++ b/Schale/MappingProfiles/Mapping.cs
@@ -163,6 +163,7 @@ namespace Schale.MappingProfiles
             CreateMap<StickerBookDB, StickerBookDBServer>();
             CreateMap<ShopFreeRecruitHistoryDB, ShopFreeRecruitHistoryDBServer>();
             CreateMap<CraftInfoDB, CraftInfoDBServer>();
+            CreateMap<MultiFloorRaidDB, MultiFloorRaidDBServer>();
         }
 
         private void ConfigureNestedDTOMappings()

--- a/Schale/MappingProfiles/Mapping.cs
+++ b/Schale/MappingProfiles/Mapping.cs
@@ -148,6 +148,14 @@ namespace Schale.MappingProfiles
             CreateMap<CostumeDB, CostumeDBServer>();
             CreateMap<StickerDB, StickerDBServer>();
             CreateMap<AccountAttachmentDB, AccountAttachmentDBServer>();
+
+            // Progression. Only the export direction existed, so accountdata load had no way
+            // to restore story or campaign history even though ExportData writes both.
+            CreateMap<ScenarioHistoryDB, ScenarioHistoryDBServer>();
+            CreateMap<ScenarioGroupHistoryDB, ScenarioGroupHistoryDBServer>();
+            CreateMap<CampaignStageHistoryDB, CampaignStageHistoryDBServer>();
+            CreateMap<CampaignChapterClearRewardHistoryDB, CampaignChapterClearRewardHistoryDBServer>();
+            CreateMap<StrategyObjectHistoryDB, StrategyObjectHistoryDBServer>();
         }
 
         private void ConfigureNestedDTOMappings()

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -433,6 +433,19 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
+            // Multi-floor raid: cleared floor and reward progress per season.
+            var multiFloorRaids = accountLoginSyncData.MultiFloorRaidSyncResponse?.MultiFloorRaidDBs;
+            if (multiFloorRaids != null)
+            {
+                context.MultiFloorRaids.RemoveRange(context.MultiFloorRaids.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var rows = connection.Mapper.Map<List<MultiFloorRaidDBServer>>(multiFloorRaids);
+                foreach (var row in rows) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.MultiFloorRaids.AddRange(rows);
+                await context.SaveChangesAsync();
+            }
+
             // Free-recruit history gates the daily free pull, so importing without it hands the
             // account a free pull it has already used.
             var freeRecruits = accountLoginSyncData.ShopGachaRecruitListResponse?.ShopFreeRecruitHistoryDBs;

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -433,6 +433,34 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
+            // Free-recruit history gates the daily free pull, so importing without it hands the
+            // account a free pull it has already used.
+            var freeRecruits = accountLoginSyncData.ShopGachaRecruitListResponse?.ShopFreeRecruitHistoryDBs;
+            if (freeRecruits != null)
+            {
+                context.ShopFreeRecruitHistories.RemoveRange(context.ShopFreeRecruitHistories.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var rows = connection.Mapper.Map<List<ShopFreeRecruitHistoryDBServer>>(freeRecruits);
+                foreach (var row in rows) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.ShopFreeRecruitHistories.AddRange(rows);
+                await context.SaveChangesAsync();
+            }
+
+            // Crafting slots in progress. CraftPresetSlotDBs from the same response have no
+            // server table, so preset slots are not restorable.
+            var craftInfos = accountLoginSyncData.CraftInfoListResponse?.CraftInfos;
+            if (craftInfos != null)
+            {
+                context.CraftInfos.RemoveRange(context.CraftInfos.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var rows = connection.Mapper.Map<List<CraftInfoDBServer>>(craftInfos);
+                foreach (var row in rows) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.CraftInfos.AddRange(rows);
+                await context.SaveChangesAsync();
+            }
+
             var idCardBackgrounds = accountLoginSyncData.IdCardBackgroundDBs;
             if (idCardBackgrounds != null)
             {

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -121,6 +121,9 @@ namespace Shittim.Commands
             await context.SaveChangesAsync();
 
             context.Weapons.RemoveRange(context.Weapons.Where(x => x.AccountServerId == connection.AccountServerId));
+            // Flush before AddWeapons: like AddItems and AddEquipment it decides insert-vs-merge
+            // with a DB query, so rows only marked Deleted still come back and get merged onto.
+            await context.SaveChangesAsync();
 
             foreach (var weapon in accountLoginSyncData.CharacterListResponse.WeaponDBs)
             {
@@ -169,6 +172,7 @@ namespace Shittim.Commands
             await context.SaveChangesAsync();
 
             context.Gears.RemoveRange(context.Gears.Where(x => x.AccountServerId == connection.AccountServerId));
+            await context.SaveChangesAsync();   // same reason as the weapons flush above
 
             foreach (var gear in accountLoginSyncData.CharacterGearListResponse.GearDBs)
             {
@@ -185,6 +189,11 @@ namespace Shittim.Commands
             Dictionary<long, EquipmentDB> oldToNewEquipmentServerId = new Dictionary<long, EquipmentDB>();
 
             context.Equipments.RemoveRange(context.GetAccountEquipments(connection.AccountServerId));
+            // Flush before AddEquipment. It merges an incoming row onto an existing one when the
+            // incoming row is an unequipped stack (BoundCharacterServerId == default), and
+            // without this the "existing" row it finds may be one pending deletion -- silently
+            // losing every unequipped stack whose UniqueId the account already had.
+            await context.SaveChangesAsync();
 
             foreach (var equipment in accountLoginSyncData.EquipmentItemListResponse.EquipmentDBs)
             {
@@ -344,6 +353,96 @@ namespace Shittim.Commands
                 foreach (var row in strategyObjects) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
                 context.StrategyObjectHistories.AddRange(strategyObjects);
 
+                await context.SaveChangesAsync();
+            }
+
+            // Collections: costumes, emblems, momotalk, permanent event progress, stickers and
+            // the attachment row. Same re-owning as above, except where a row points back at a
+            // character -- those take the same ServerId remap weapons and gear already get.
+            var costumeList = accountLoginSyncData.CharacterListResponse?.CostumeDBs;
+            if (costumeList != null)
+            {
+                context.Costumes.RemoveRange(context.Costumes.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var costumes = connection.Mapper.Map<List<CostumeDBServer>>(costumeList);
+                foreach (var row in costumes)
+                {
+                    if (oldToNewCharacterServerId.TryGetValue(row.BoundCharacterServerId, out var owner))
+                        row.BoundCharacterServerId = owner.ServerId;
+                    row.ServerId = 0;
+                    row.AccountServerId = connection.AccountServerId;
+                }
+                context.Costumes.AddRange(costumes);
+                await context.SaveChangesAsync();
+            }
+
+            var emblemList = accountLoginSyncData.AttachmentEmblemListResponse?.EmblemDBs;
+            if (emblemList != null)
+            {
+                context.Emblems.RemoveRange(context.Emblems.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var emblems = connection.Mapper.Map<List<EmblemDBServer>>(emblemList);
+                foreach (var row in emblems) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.Emblems.AddRange(emblems);
+                await context.SaveChangesAsync();
+            }
+
+            var momotalkList = accountLoginSyncData.MomotalkOutlineResponse?.MomoTalkOutLineDBs;
+            if (momotalkList != null)
+            {
+                context.MomoTalkOutLines.RemoveRange(context.MomoTalkOutLines.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var momotalks = connection.Mapper.Map<List<MomoTalkOutLineDBServer>>(momotalkList);
+                foreach (var row in momotalks)
+                {
+                    // CharacterDBId is a character ServerId, so it moves with the roster.
+                    if (oldToNewCharacterServerId.TryGetValue(row.CharacterDBId, out var owner))
+                        row.CharacterDBId = owner.ServerId;
+                    row.ServerId = 0;
+                    row.AccountServerId = connection.AccountServerId;
+                }
+                context.MomoTalkOutLines.AddRange(momotalks);
+                await context.SaveChangesAsync();
+            }
+
+            var eventPermanentList = accountLoginSyncData.EventContentPermanentListResponse?.PermanentDBs;
+            if (eventPermanentList != null)
+            {
+                context.EventContentPermanents.RemoveRange(context.EventContentPermanents.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var permanents = connection.Mapper.Map<List<EventContentPermanentDBServer>>(eventPermanentList);
+                foreach (var row in permanents) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.EventContentPermanents.AddRange(permanents);
+                await context.SaveChangesAsync();
+            }
+
+            var stickerBook = accountLoginSyncData.StickerListResponse?.StickerBookDB;
+            if (stickerBook != null)
+            {
+                context.StickerBooks.RemoveRange(context.StickerBooks.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var book = connection.Mapper.Map<StickerBookDBServer>(stickerBook);
+                book.ServerId = 0;
+                book.AccountServerId = connection.AccountServerId;
+                context.StickerBooks.Add(book);
+                await context.SaveChangesAsync();
+            }
+
+            var attachment = accountLoginSyncData.AttachmentGetResponse?.AccountAttachmentDB;
+            if (attachment != null)
+            {
+                context.AccountAttachments.RemoveRange(context.AccountAttachments.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var row = connection.Mapper.Map<AccountAttachmentDBServer>(attachment);
+                row.ServerId = 0;
+                row.AccountServerId = connection.AccountServerId;
+                context.AccountAttachments.Add(row);
                 await context.SaveChangesAsync();
             }
 

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -85,15 +85,11 @@ namespace Shittim.Commands
             account.Comment = accountAuthData.AccountDB.Comment;
             account.CallName = accountAuthData.AccountDB.CallName;
 
-            // Assigned field by field rather than through the mapper, to leave the row's own
-            // ServerId and AccountServerId alone.
+            // Assigned field by field rather than mapped, so the row keeps its own ServerId and AccountServerId.
             var incomingCurrency = accountLoginSyncData.AccountCurrencySyncResponse?.AccountCurrencyDB;
             if (incomingCurrency?.CurrencyDict != null)
             {
-                // Amounts transfer, timestamps do not. Time-charged currencies recharge as
-                // (now - UpdateTime) / interval, so a save from a server whose clock is ahead
-                // of this one would give a negative elapsed and subtract. Stamping them with
-                // this server's now makes recharge resume from the import.
+                // Time-charged currencies recharge as (now - UpdateTime) / interval, so timestamps from a server whose clock is ahead of this one make the recharge subtract; restamping resumes it from the import instead.
                 var chargedAt = account.GameSettings.ServerDateTime();
                 var updateTimes = (incomingCurrency.UpdateTimeDict ?? [])
                     .ToDictionary(entry => entry.Key, _ => chargedAt);
@@ -122,10 +118,7 @@ namespace Shittim.Commands
 
             context.Characters.RemoveRange(context.Characters.Where(x => x.AccountServerId == connection.AccountServerId));
 
-            // ServerId is the key of a table shared by every account, so the save's own ids
-            // collide when it is imported twice. Zero them and let the database assign. The map
-            // must hold the inserted instances: everything pointing at a character reads its new
-            // id back out of here after the save below.
+            // ServerId keys a table shared by every account, so the save's own ids collide on a second import; zero them and let the database assign. The map must hold the inserted instances, since everything pointing at a character reads its new id back out of here after the save.
             var sourceCharacters = accountLoginSyncData.CharacterListResponse.CharacterDBs.ToList();
             var characterData = connection.Mapper.Map<List<CharacterDBServer>>(sourceCharacters);
             Dictionary<long, CharacterDBServer> oldToNewCharacterServerId = new();
@@ -138,14 +131,11 @@ namespace Shittim.Commands
             var charactersAdded = context.AddCharacters(connection.AccountServerId, characterData.ToArray());
             await context.SaveChangesAsync();
 
-            // The account's represent character points at one of the ids just replaced.
             if (oldToNewCharacterServerId.TryGetValue(account.RepresentCharacterServerId, out var represent))
                 account.RepresentCharacterServerId = represent.ServerId;
 
             context.Weapons.RemoveRange(context.Weapons.Where(x => x.AccountServerId == connection.AccountServerId));
-            // AddWeapons, AddGears, AddItems and AddEquipment decide insert-vs-merge with a DB
-            // query, which still returns rows that are only marked Deleted. Without flushing
-            // first they merge onto a row about to be deleted and the incoming one is lost.
+            // AddWeapons, AddGears, AddItems and AddEquipment pick insert vs merge with a DB query, which still returns rows only marked Deleted, so without flushing first they merge onto a doomed row and the incoming one is lost.
             await context.SaveChangesAsync();
 
             foreach (var weapon in accountLoginSyncData.CharacterListResponse.WeaponDBs)
@@ -174,8 +164,7 @@ namespace Shittim.Commands
                 }
             }
 
-            // Outside the if/else above, so a list recovered from the separate packet is
-            // written too rather than only one taken from the login bundle.
+            // Outside the if/else above so a list recovered from the separate packet is written too, not only one taken from the login bundle.
             if (accountLoginSyncData.ItemListResponse?.ItemDBs != null)
             {
                 context.Items.RemoveRange(context.Items.Where(x => x.AccountServerId == connection.AccountServerId));
@@ -204,8 +193,7 @@ namespace Shittim.Commands
             context.Equipments.RemoveRange(context.GetAccountEquipments(connection.AccountServerId));
             await context.SaveChangesAsync();
 
-            // Same as characters: zero the key so the database assigns a fresh one, and keep the
-            // inserted instances so the characters below can find what their gear became.
+            // As with characters: zero the key, and keep the inserted instances so the characters below can find what their gear became.
             var sourceEquipment = accountLoginSyncData.EquipmentItemListResponse.EquipmentDBs.ToList();
             var equipmentData = connection.Mapper.Map<List<EquipmentDBServer>>(sourceEquipment);
             Dictionary<long, EquipmentDBServer> oldToNewEquipmentServerId = new();
@@ -325,9 +313,7 @@ namespace Shittim.Commands
 
             await context.SaveChangesAsync();
 
-            // Story and campaign progress. Without these the account is a max-level roster
-            // with every content gate still shut. The rows carry no cross-references, so they
-            // only need re-owning: zero the key for a fresh one, and set AccountServerId.
+            // Without story and campaign progress the account is max level with every content gate still shut. These rows carry no cross-references, so re-owning them is enough.
             var scenarioList = accountLoginSyncData.ScenarioListResponse;
             if (scenarioList != null)
             {
@@ -369,8 +355,6 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            // Collections. Same re-owning, except rows pointing back at a character, which
-            // take the same ServerId remap weapons and gear already get.
             var costumeList = accountLoginSyncData.CharacterListResponse?.CostumeDBs;
             if (costumeList != null)
             {
@@ -445,7 +429,6 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            // Cleared floor and reward progress per season.
             var multiFloorRaids = accountLoginSyncData.MultiFloorRaidSyncResponse?.MultiFloorRaidDBs;
             if (multiFloorRaids != null)
             {
@@ -458,7 +441,6 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            // Gates the daily free pull.
             var freeRecruits = accountLoginSyncData.ShopGachaRecruitListResponse?.ShopFreeRecruitHistoryDBs;
             if (freeRecruits != null)
             {
@@ -471,7 +453,7 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            // In-progress crafts. CraftPresetSlotDBs have no server table.
+            // CraftPresetSlotDBs from the same response have no server table.
             var craftInfos = accountLoginSyncData.CraftInfoListResponse?.CraftInfos;
             if (craftInfos != null)
             {
@@ -499,9 +481,7 @@ namespace Shittim.Commands
             var idCard = accountLoginSyncData.FriendIdCardDB;
             if (idCard != null)
             {
-                // Settings live on the account as JSON, the same shape FriendHandler writes.
-                // FriendCode, Level and LastConnectTime identify the account on THIS server,
-                // so they are not copied.
+                // Settings live on the account as JSON, the same shape FriendHandler writes. FriendCode, Level and LastConnectTime identify the account on this server, so they are not copied.
                 var card = account.ContentInfo.IdCard;
                 card.Comment = idCard.Comment;
                 card.RepresentCharacterUniqueId = idCard.RepresentCharacterUniqueId;

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -86,11 +86,23 @@ namespace Shittim.Commands
             var incomingCurrency = accountLoginSyncData.AccountCurrencySyncResponse?.AccountCurrencyDB;
             if (incomingCurrency?.CurrencyDict != null)
             {
+                // The AMOUNTS transfer; the update timestamps must not. They record when each
+                // currency was last recharged, on the clock of the server the save came from,
+                // and time-charged currencies are topped up as (now - UpdateTime) / interval.
+                // A save from a server whose clock is ahead of this one therefore yields a
+                // NEGATIVE elapsed and *subtracts*: an import carrying 20:44 into a server
+                // sitting at 05:49 produced 56 AP - 149 = -93 AP on the client.
+                // Stamping them with this server's now means recharge simply resumes from the
+                // import, which is what the amounts already represent.
+                var chargedAt = account.GameSettings.ServerDateTime();
+                var updateTimes = (incomingCurrency.UpdateTimeDict ?? [])
+                    .ToDictionary(entry => entry.Key, _ => chargedAt);
+
                 var currency = context.GetAccountCurrencies(connection.AccountServerId).FirstOrDefault();
                 if (currency != null)
                 {
                     currency.CurrencyDict = incomingCurrency.CurrencyDict;
-                    currency.UpdateTimeDict = incomingCurrency.UpdateTimeDict ?? currency.UpdateTimeDict;
+                    currency.UpdateTimeDict = updateTimes;
                     currency.AccountLevel = incomingCurrency.AccountLevel;
                     currency.AcademyLocationRankSum = incomingCurrency.AcademyLocationRankSum;
                 }
@@ -100,7 +112,7 @@ namespace Shittim.Commands
                     {
                         AccountServerId = connection.AccountServerId,
                         CurrencyDict = incomingCurrency.CurrencyDict,
-                        UpdateTimeDict = incomingCurrency.UpdateTimeDict ?? [],
+                        UpdateTimeDict = updateTimes,
                         AccountLevel = incomingCurrency.AccountLevel,
                         AcademyLocationRankSum = incomingCurrency.AcademyLocationRankSum,
                     });

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -111,7 +111,11 @@ namespace Shittim.Commands
                     await connection.SendChatMessage("Could not find any packet associated with item data.");
                 }
             }
-            else
+
+            // Insert whichever source we ended up with. This used to sit in an `else`, so a
+            // list recovered from the separate packet was assigned above and then never
+            // written -- the import silently produced an account with no items at all.
+            if (accountLoginSyncData.ItemListResponse?.ItemDBs != null)
             {
                 context.Items.RemoveRange(context.Items.Where(x => x.AccountServerId == connection.AccountServerId));
                 context.AddItems(connection.AccountServerId, accountLoginSyncData.ItemListResponse.ItemDBs.ToArray());

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -73,6 +73,37 @@ namespace Shittim.Commands
             account.Exp = accountAuthData.AccountDB.Exp;
             account.RepresentCharacterServerId = accountAuthData.AccountDB.RepresentCharacterServerId;
 
+            // Currencies. ExportData writes AccountCurrencySyncResponse and the import DTO has
+            // carried the field all along, but nothing here ever read it back, so pyroxene,
+            // credits, AP, eligma and every ticket silently kept the target account's values
+            // while the rest of the account was replaced -- the export/import round trip was
+            // not lossless. Assigned field by field rather than through the mapper so the row's
+            // own ServerId/AccountServerId are left alone.
+            var incomingCurrency = accountLoginSyncData.AccountCurrencySyncResponse?.AccountCurrencyDB;
+            if (incomingCurrency?.CurrencyDict != null)
+            {
+                var currency = context.GetAccountCurrencies(connection.AccountServerId).FirstOrDefault();
+                if (currency != null)
+                {
+                    currency.CurrencyDict = incomingCurrency.CurrencyDict;
+                    currency.UpdateTimeDict = incomingCurrency.UpdateTimeDict ?? currency.UpdateTimeDict;
+                    currency.AccountLevel = incomingCurrency.AccountLevel;
+                    currency.AcademyLocationRankSum = incomingCurrency.AcademyLocationRankSum;
+                }
+                else
+                {
+                    context.Currencies.Add(new AccountCurrencyDBServer
+                    {
+                        AccountServerId = connection.AccountServerId,
+                        CurrencyDict = incomingCurrency.CurrencyDict,
+                        UpdateTimeDict = incomingCurrency.UpdateTimeDict ?? [],
+                        AccountLevel = incomingCurrency.AccountLevel,
+                        AcademyLocationRankSum = incomingCurrency.AcademyLocationRankSum,
+                    });
+                }
+                await context.SaveChangesAsync();
+            }
+
             Dictionary<long, CharacterDBServer> oldToNewCharacterServerId = new();
 
             foreach (var character in accountLoginSyncData.CharacterListResponse.CharacterDBs)

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -114,7 +114,9 @@ namespace Shittim.Commands
 
             // Insert whichever source we ended up with. This used to sit in an `else`, so a
             // list recovered from the separate packet was assigned above and then never
-            // written -- the import silently produced an account with no items at all.
+            // written: neither the clear nor the insert ran, leaving the account holding
+            // its previous items while every other category had been replaced. Silent --
+            // the catch above only fires when the packet is absent or malformed.
             if (accountLoginSyncData.ItemListResponse?.ItemDBs != null)
             {
                 context.Items.RemoveRange(context.Items.Where(x => x.AccountServerId == connection.AccountServerId));

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -120,6 +120,15 @@ namespace Shittim.Commands
             if (accountLoginSyncData.ItemListResponse?.ItemDBs != null)
             {
                 context.Items.RemoveRange(context.Items.Where(x => x.AccountServerId == connection.AccountServerId));
+
+                // Flush the delete before AddItems runs. AddItems looks up existing rows with
+                // a DB query (context.Items.Where(...)), so rows that are only *marked*
+                // Deleted are still returned and fixed up to their tracked entity. It would
+                // then take its merge branch and add the incoming stack onto a row that is
+                // about to be deleted, so the incoming item is never inserted and vanishes on
+                // save -- losing exactly those items that collide with the previous inventory.
+                await context.SaveChangesAsync();
+
                 context.AddItems(connection.AccountServerId, accountLoginSyncData.ItemListResponse.ItemDBs.ToArray());
             }
             await context.SaveChangesAsync();

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -72,6 +72,10 @@ namespace Shittim.Commands
             account.Level = accountAuthData.AccountDB.Level;
             account.Exp = accountAuthData.AccountDB.Exp;
             account.RepresentCharacterServerId = accountAuthData.AccountDB.RepresentCharacterServerId;
+            // The greeting and sensei name are part of the account too; they were being left at
+            // whatever the target account had.
+            account.Comment = accountAuthData.AccountDB.Comment;
+            account.CallName = accountAuthData.AccountDB.CallName;
 
             // Currencies. ExportData writes AccountCurrencySyncResponse and the import DTO has
             // carried the field all along, but nothing here ever read it back, so pyroxene,
@@ -292,6 +296,56 @@ namespace Shittim.Commands
 
             var echelonData = connection.Mapper.Map<List<EchelonDBServer>>(accountLoginSyncData.EchelonListResponse.EchelonDBs);
             context.AddEchelons(connection.AccountServerId, echelonData.ToArray());
+
+            await context.SaveChangesAsync();
+
+            // Progression. Everything above restores inventory; ExportData also writes story and
+            // campaign history but nothing here read it back, so an imported account was a
+            // max-level roster with no progress behind it -- lessons, cafe and the rest of the
+            // content gates stay locked because the records that open them were never restored.
+            // These rows are keyed by their own generated ServerId and carry no cross-references,
+            // so they only need re-owning to the target account: zero the key so the database
+            // assigns a fresh one, and point AccountServerId at this account.
+            var scenarioList = accountLoginSyncData.ScenarioListResponse;
+            if (scenarioList != null)
+            {
+                context.ScenarioHistories.RemoveRange(context.ScenarioHistories.Where(x => x.AccountServerId == connection.AccountServerId));
+                context.ScenarioGroupHistories.RemoveRange(context.ScenarioGroupHistories.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var scenarioHistories = connection.Mapper.Map<List<ScenarioHistoryDBServer>>(scenarioList.ScenarioHistoryDBs ?? []);
+                foreach (var row in scenarioHistories) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.ScenarioHistories.AddRange(scenarioHistories);
+
+                var scenarioGroups = connection.Mapper.Map<List<ScenarioGroupHistoryDBServer>>(scenarioList.ScenarioGroupHistoryDBs ?? []);
+                foreach (var row in scenarioGroups) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.ScenarioGroupHistories.AddRange(scenarioGroups);
+
+                await context.SaveChangesAsync();
+            }
+
+            var campaignList = accountLoginSyncData.CampaignListResponse;
+            if (campaignList != null)
+            {
+                context.CampaignStageHistories.RemoveRange(context.CampaignStageHistories.Where(x => x.AccountServerId == connection.AccountServerId));
+                context.CampaignChapterClearRewardHistories.RemoveRange(context.CampaignChapterClearRewardHistories.Where(x => x.AccountServerId == connection.AccountServerId));
+                context.StrategyObjectHistories.RemoveRange(context.StrategyObjectHistories.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var stageHistories = connection.Mapper.Map<List<CampaignStageHistoryDBServer>>(campaignList.StageHistoryDBs ?? []);
+                foreach (var row in stageHistories) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.CampaignStageHistories.AddRange(stageHistories);
+
+                var chapterRewards = connection.Mapper.Map<List<CampaignChapterClearRewardHistoryDBServer>>(campaignList.CampaignChapterClearRewardHistoryDBs ?? []);
+                foreach (var row in chapterRewards) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.CampaignChapterClearRewardHistories.AddRange(chapterRewards);
+
+                var strategyObjects = connection.Mapper.Map<List<StrategyObjectHistoryDBServer>>(campaignList.StrategyObjecthistoryDBs ?? []);
+                foreach (var row in strategyObjects) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.StrategyObjectHistories.AddRange(strategyObjects);
+
+                await context.SaveChangesAsync();
+            }
 
             await context.SaveChangesAsync();
             await connection.SendChatMessage("Successfully Loaded All Data from the save file.");

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -18,9 +18,7 @@ namespace Shittim.Commands
         [Argument(0, @"^(list|load|export|help)$", "The operation to perform", ArgumentFlags.IgnoreCase)]
         public string Operation { get; set; } = string.Empty;
 
-        // Optional: `list` and `help` take no file name, and requiring one made them impossible
-        // to invoke -- Validate() rejected them with "Invalid args length!" before Execute ran.
-        // `load` and `export` check for it themselves below.
+        // Optional so `list` and `help` can run; `load` and `export` check for it themselves.
         [Argument(1, @"^.*$", "The file name of the packet json saved or Operation",
                   ArgumentFlags.Optional | ArgumentFlags.IgnoreCase)]
         public string DataFileName { get; set; } = string.Empty;
@@ -84,28 +82,18 @@ namespace Shittim.Commands
             account.Level = accountAuthData.AccountDB.Level;
             account.Exp = accountAuthData.AccountDB.Exp;
             account.RepresentCharacterServerId = accountAuthData.AccountDB.RepresentCharacterServerId;
-            // The greeting and sensei name are part of the account too; they were being left at
-            // whatever the target account had.
             account.Comment = accountAuthData.AccountDB.Comment;
             account.CallName = accountAuthData.AccountDB.CallName;
 
-            // Currencies. ExportData writes AccountCurrencySyncResponse and the import DTO has
-            // carried the field all along, but nothing here ever read it back, so pyroxene,
-            // credits, AP, eligma and every ticket silently kept the target account's values
-            // while the rest of the account was replaced -- the export/import round trip was
-            // not lossless. Assigned field by field rather than through the mapper so the row's
-            // own ServerId/AccountServerId are left alone.
+            // Assigned field by field rather than through the mapper, to leave the row's own
+            // ServerId and AccountServerId alone.
             var incomingCurrency = accountLoginSyncData.AccountCurrencySyncResponse?.AccountCurrencyDB;
             if (incomingCurrency?.CurrencyDict != null)
             {
-                // The AMOUNTS transfer; the update timestamps must not. They record when each
-                // currency was last recharged, on the clock of the server the save came from,
-                // and time-charged currencies are topped up as (now - UpdateTime) / interval.
-                // A save from a server whose clock is ahead of this one therefore yields a
-                // NEGATIVE elapsed and *subtracts*: an import carrying 20:44 into a server
-                // sitting at 05:49 produced 56 AP - 149 = -93 AP on the client.
-                // Stamping them with this server's now means recharge simply resumes from the
-                // import, which is what the amounts already represent.
+                // Amounts transfer, timestamps do not. Time-charged currencies recharge as
+                // (now - UpdateTime) / interval, so a save from a server whose clock is ahead
+                // of this one would give a negative elapsed and subtract. Stamping them with
+                // this server's now makes recharge resume from the import.
                 var chargedAt = account.GameSettings.ServerDateTime();
                 var updateTimes = (incomingCurrency.UpdateTimeDict ?? [])
                     .ToDictionary(entry => entry.Key, _ => chargedAt);
@@ -145,8 +133,9 @@ namespace Shittim.Commands
             await context.SaveChangesAsync();
 
             context.Weapons.RemoveRange(context.Weapons.Where(x => x.AccountServerId == connection.AccountServerId));
-            // Flush before AddWeapons: like AddItems and AddEquipment it decides insert-vs-merge
-            // with a DB query, so rows only marked Deleted still come back and get merged onto.
+            // AddWeapons, AddGears, AddItems and AddEquipment decide insert-vs-merge with a DB
+            // query, which still returns rows that are only marked Deleted. Without flushing
+            // first they merge onto a row about to be deleted and the incoming one is lost.
             await context.SaveChangesAsync();
 
             foreach (var weapon in accountLoginSyncData.CharacterListResponse.WeaponDBs)
@@ -174,29 +163,18 @@ namespace Shittim.Commands
                 }
             }
 
-            // Insert whichever source we ended up with. This used to sit in an `else`, so a
-            // list recovered from the separate packet was assigned above and then never
-            // written: neither the clear nor the insert ran, leaving the account holding
-            // its previous items while every other category had been replaced. Silent --
-            // the catch above only fires when the packet is absent or malformed.
+            // Outside the if/else above, so a list recovered from the separate packet is
+            // written too rather than only one taken from the login bundle.
             if (accountLoginSyncData.ItemListResponse?.ItemDBs != null)
             {
                 context.Items.RemoveRange(context.Items.Where(x => x.AccountServerId == connection.AccountServerId));
-
-                // Flush the delete before AddItems runs. AddItems looks up existing rows with
-                // a DB query (context.Items.Where(...)), so rows that are only *marked*
-                // Deleted are still returned and fixed up to their tracked entity. It would
-                // then take its merge branch and add the incoming stack onto a row that is
-                // about to be deleted, so the incoming item is never inserted and vanishes on
-                // save -- losing exactly those items that collide with the previous inventory.
                 await context.SaveChangesAsync();
-
                 context.AddItems(connection.AccountServerId, accountLoginSyncData.ItemListResponse.ItemDBs.ToArray());
             }
             await context.SaveChangesAsync();
 
             context.Gears.RemoveRange(context.Gears.Where(x => x.AccountServerId == connection.AccountServerId));
-            await context.SaveChangesAsync();   // same reason as the weapons flush above
+            await context.SaveChangesAsync();
 
             foreach (var gear in accountLoginSyncData.CharacterGearListResponse.GearDBs)
             {
@@ -213,10 +191,6 @@ namespace Shittim.Commands
             Dictionary<long, EquipmentDB> oldToNewEquipmentServerId = new Dictionary<long, EquipmentDB>();
 
             context.Equipments.RemoveRange(context.GetAccountEquipments(connection.AccountServerId));
-            // Flush before AddEquipment. It merges an incoming row onto an existing one when the
-            // incoming row is an unequipped stack (BoundCharacterServerId == default), and
-            // without this the "existing" row it finds may be one pending deletion -- silently
-            // losing every unequipped stack whose UniqueId the account already had.
             await context.SaveChangesAsync();
 
             foreach (var equipment in accountLoginSyncData.EquipmentItemListResponse.EquipmentDBs)
@@ -332,13 +306,9 @@ namespace Shittim.Commands
 
             await context.SaveChangesAsync();
 
-            // Progression. Everything above restores inventory; ExportData also writes story and
-            // campaign history but nothing here read it back, so an imported account was a
-            // max-level roster with no progress behind it -- lessons, cafe and the rest of the
-            // content gates stay locked because the records that open them were never restored.
-            // These rows are keyed by their own generated ServerId and carry no cross-references,
-            // so they only need re-owning to the target account: zero the key so the database
-            // assigns a fresh one, and point AccountServerId at this account.
+            // Story and campaign progress. Without these the account is a max-level roster
+            // with every content gate still shut. The rows carry no cross-references, so they
+            // only need re-owning: zero the key for a fresh one, and set AccountServerId.
             var scenarioList = accountLoginSyncData.ScenarioListResponse;
             if (scenarioList != null)
             {
@@ -380,9 +350,8 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            // Collections: costumes, emblems, momotalk, permanent event progress, stickers and
-            // the attachment row. Same re-owning as above, except where a row points back at a
-            // character -- those take the same ServerId remap weapons and gear already get.
+            // Collections. Same re-owning, except rows pointing back at a character, which
+            // take the same ServerId remap weapons and gear already get.
             var costumeList = accountLoginSyncData.CharacterListResponse?.CostumeDBs;
             if (costumeList != null)
             {
@@ -457,7 +426,7 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            // Multi-floor raid: cleared floor and reward progress per season.
+            // Cleared floor and reward progress per season.
             var multiFloorRaids = accountLoginSyncData.MultiFloorRaidSyncResponse?.MultiFloorRaidDBs;
             if (multiFloorRaids != null)
             {
@@ -470,8 +439,7 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            // Free-recruit history gates the daily free pull, so importing without it hands the
-            // account a free pull it has already used.
+            // Gates the daily free pull.
             var freeRecruits = accountLoginSyncData.ShopGachaRecruitListResponse?.ShopFreeRecruitHistoryDBs;
             if (freeRecruits != null)
             {
@@ -484,8 +452,7 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            // Crafting slots in progress. CraftPresetSlotDBs from the same response have no
-            // server table, so preset slots are not restorable.
+            // In-progress crafts. CraftPresetSlotDBs have no server table.
             var craftInfos = accountLoginSyncData.CraftInfoListResponse?.CraftInfos;
             if (craftInfos != null)
             {
@@ -513,10 +480,9 @@ namespace Shittim.Commands
             var idCard = accountLoginSyncData.FriendIdCardDB;
             if (idCard != null)
             {
-                // Settings live as a JSON column on the account (ContentInfo), not a table --
-                // same shape FriendHandler writes when the card is edited in game. FriendCode,
-                // Level and LastConnectTime are deliberately not copied: those belong to the
-                // account on THIS server, not to the one the save came from.
+                // Settings live on the account as JSON, the same shape FriendHandler writes.
+                // FriendCode, Level and LastConnectTime identify the account on THIS server,
+                // so they are not copied.
                 var card = account.ContentInfo.IdCard;
                 card.Comment = idCard.Comment;
                 card.RepresentCharacterUniqueId = idCard.RepresentCharacterUniqueId;

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -433,6 +433,43 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
+            var idCardBackgrounds = accountLoginSyncData.IdCardBackgroundDBs;
+            if (idCardBackgrounds != null)
+            {
+                context.IdCardBackgrounds.RemoveRange(context.IdCardBackgrounds.Where(x => x.AccountServerId == connection.AccountServerId));
+                await context.SaveChangesAsync();
+
+                var backgrounds = connection.Mapper.Map<List<IdCardBackgroundDBServer>>(idCardBackgrounds);
+                foreach (var row in backgrounds) { row.ServerId = 0; row.AccountServerId = connection.AccountServerId; }
+                context.IdCardBackgrounds.AddRange(backgrounds);
+                await context.SaveChangesAsync();
+            }
+
+            var idCard = accountLoginSyncData.FriendIdCardDB;
+            if (idCard != null)
+            {
+                // Settings live as a JSON column on the account (ContentInfo), not a table --
+                // same shape FriendHandler writes when the card is edited in game. FriendCode,
+                // Level and LastConnectTime are deliberately not copied: those belong to the
+                // account on THIS server, not to the one the save came from.
+                var card = account.ContentInfo.IdCard;
+                card.Comment = idCard.Comment;
+                card.RepresentCharacterUniqueId = idCard.RepresentCharacterUniqueId;
+                card.RepresentCharacterCostumeId = idCard.RepresentCharacterCostumeId;
+                card.CardBackgroundId = idCard.CardBackgroundId;
+                card.SearchPermission = idCard.SearchPermission;
+                card.AutoAcceptFriendRequest = idCard.AutoAcceptFriendRequest;
+                card.ShowAccountLevel = idCard.ShowAccountLevel;
+                card.ShowFriendCode = idCard.ShowFriendCode;
+                card.ShowRaidRanking = idCard.ShowRaidRanking;
+                card.ShowArenaRanking = idCard.ShowArenaRanking;
+                card.ShowEliminateRaidRanking = idCard.ShowEliminateRaidRanking;
+                card.ShowMultiFloorRaidClearedDifficulty = idCard.ShowMultiFloorRaidClearedDifficulty;
+
+                context.Entry(account).Property(x => x.ContentInfo).IsModified = true;
+                await context.SaveChangesAsync();
+            }
+
             var attachment = accountLoginSyncData.AttachmentGetResponse?.AccountAttachmentDB;
             if (attachment != null)
             {

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -120,17 +120,27 @@ namespace Shittim.Commands
                 await context.SaveChangesAsync();
             }
 
-            Dictionary<long, CharacterDBServer> oldToNewCharacterServerId = new();
+            context.Characters.RemoveRange(context.Characters.Where(x => x.AccountServerId == connection.AccountServerId));
 
-            foreach (var character in accountLoginSyncData.CharacterListResponse.CharacterDBs)
+            // ServerId is the key of a table shared by every account, so the save's own ids
+            // collide when it is imported twice. Zero them and let the database assign. The map
+            // must hold the inserted instances: everything pointing at a character reads its new
+            // id back out of here after the save below.
+            var sourceCharacters = accountLoginSyncData.CharacterListResponse.CharacterDBs.ToList();
+            var characterData = connection.Mapper.Map<List<CharacterDBServer>>(sourceCharacters);
+            Dictionary<long, CharacterDBServer> oldToNewCharacterServerId = new();
+            for (var i = 0; i < sourceCharacters.Count; i++)
             {
-                oldToNewCharacterServerId.Add(character.ServerId, connection.Mapper.Map<CharacterDBServer>(character));
+                oldToNewCharacterServerId[sourceCharacters[i].ServerId] = characterData[i];
+                characterData[i].ServerId = 0;
             }
 
-            context.Characters.RemoveRange(context.Characters.Where(x => x.AccountServerId == connection.AccountServerId));
-            var characterData = connection.Mapper.Map<List<CharacterDBServer>>(accountLoginSyncData.CharacterListResponse.CharacterDBs);
             var charactersAdded = context.AddCharacters(connection.AccountServerId, characterData.ToArray());
             await context.SaveChangesAsync();
+
+            // The account's represent character points at one of the ids just replaced.
+            if (oldToNewCharacterServerId.TryGetValue(account.RepresentCharacterServerId, out var represent))
+                account.RepresentCharacterServerId = represent.ServerId;
 
             context.Weapons.RemoveRange(context.Weapons.Where(x => x.AccountServerId == connection.AccountServerId));
             // AddWeapons, AddGears, AddItems and AddEquipment decide insert-vs-merge with a DB
@@ -147,6 +157,7 @@ namespace Shittim.Commands
             }
 
             var weaponData = connection.Mapper.Map<List<WeaponDBServer>>(accountLoginSyncData.CharacterListResponse.WeaponDBs);
+            weaponData.ForEach(x => x.ServerId = 0);
             context.AddWeapons(connection.AccountServerId, weaponData.ToArray());
             await context.SaveChangesAsync();
 
@@ -169,6 +180,7 @@ namespace Shittim.Commands
             {
                 context.Items.RemoveRange(context.Items.Where(x => x.AccountServerId == connection.AccountServerId));
                 await context.SaveChangesAsync();
+                accountLoginSyncData.ItemListResponse.ItemDBs.ForEach(x => x.ServerId = 0);
                 context.AddItems(connection.AccountServerId, accountLoginSyncData.ItemListResponse.ItemDBs.ToArray());
             }
             await context.SaveChangesAsync();
@@ -185,20 +197,24 @@ namespace Shittim.Commands
             }
 
             var gearData = connection.Mapper.Map<List<GearDBServer>>(accountLoginSyncData.CharacterGearListResponse.GearDBs);
+            gearData.ForEach(x => x.ServerId = 0);
             context.AddGears(connection.AccountServerId, gearData.ToArray());
             await context.SaveChangesAsync();
-
-            Dictionary<long, EquipmentDB> oldToNewEquipmentServerId = new Dictionary<long, EquipmentDB>();
 
             context.Equipments.RemoveRange(context.GetAccountEquipments(connection.AccountServerId));
             await context.SaveChangesAsync();
 
-            foreach (var equipment in accountLoginSyncData.EquipmentItemListResponse.EquipmentDBs)
+            // Same as characters: zero the key so the database assigns a fresh one, and keep the
+            // inserted instances so the characters below can find what their gear became.
+            var sourceEquipment = accountLoginSyncData.EquipmentItemListResponse.EquipmentDBs.ToList();
+            var equipmentData = connection.Mapper.Map<List<EquipmentDBServer>>(sourceEquipment);
+            Dictionary<long, EquipmentDBServer> oldToNewEquipmentServerId = new();
+            for (var i = 0; i < sourceEquipment.Count; i++)
             {
-                oldToNewEquipmentServerId.Add(equipment.ServerId, equipment);
+                oldToNewEquipmentServerId[sourceEquipment[i].ServerId] = equipmentData[i];
+                equipmentData[i].ServerId = 0;
             }
 
-            var equipmentData = connection.Mapper.Map<List<EquipmentDBServer>>(accountLoginSyncData.EquipmentItemListResponse.EquipmentDBs);
             context.AddEquipment(connection.AccountServerId, equipmentData.ToArray());
             await context.SaveChangesAsync();
 
@@ -215,6 +231,7 @@ namespace Shittim.Commands
 
             context.MemoryLobbies.RemoveRange(context.MemoryLobbies.Where(x => x.AccountServerId == connection.AccountServerId));
             var memoryLobbyData = connection.Mapper.Map<List<MemoryLobbyDBServer>>(accountLoginSyncData.MemoryLobbyListResponse.MemoryLobbyDBs);
+            memoryLobbyData.ForEach(x => x.ServerId = 0);
             context.AddMemoryLobbies(connection.AccountServerId, memoryLobbyData.ToArray());
 
             Dictionary<long, long> oldCafeDbIdToCafeId = new();
@@ -257,6 +274,7 @@ namespace Shittim.Commands
             }
 
             var furnitureData = connection.Mapper.Map<List<FurnitureDBServer>>(accountLoginSyncData.CafeGetInfoResponse.FurnitureDBs);
+            furnitureData.ForEach(x => x.ServerId = 0);
             context.AddFurnitures(connection.AccountServerId, furnitureData.ToArray());
             await context.SaveChangesAsync();
 
@@ -302,6 +320,7 @@ namespace Shittim.Commands
             }
 
             var echelonData = connection.Mapper.Map<List<EchelonDBServer>>(accountLoginSyncData.EchelonListResponse.EchelonDBs);
+            echelonData.ForEach(x => x.ServerId = 0);
             context.AddEchelons(connection.AccountServerId, echelonData.ToArray());
 
             await context.SaveChangesAsync();

--- a/Shittim-Server/Commands/AccountDataCommand.cs
+++ b/Shittim-Server/Commands/AccountDataCommand.cs
@@ -18,7 +18,11 @@ namespace Shittim.Commands
         [Argument(0, @"^(list|load|export|help)$", "The operation to perform", ArgumentFlags.IgnoreCase)]
         public string Operation { get; set; } = string.Empty;
 
-        [Argument(1, @"^.*$", "The file name of the packet json saved or Operation", ArgumentFlags.IgnoreCase)]
+        // Optional: `list` and `help` take no file name, and requiring one made them impossible
+        // to invoke -- Validate() rejected them with "Invalid args length!" before Execute ran.
+        // `load` and `export` check for it themselves below.
+        [Argument(1, @"^.*$", "The file name of the packet json saved or Operation",
+                  ArgumentFlags.Optional | ArgumentFlags.IgnoreCase)]
         public string DataFileName { get; set; } = string.Empty;
 
         public static string accountDataDir = Path.Combine(Path.GetDirectoryName(AppContext.BaseDirectory), "AccountData");
@@ -31,7 +35,15 @@ namespace Shittim.Commands
             using var context = await connection.Context.CreateDbContextAsync();
             var account = context.GetAccount(connection.AccountServerId);
 
-            switch (Operation.ToLower())
+            var operation = Operation.ToLower();
+            if ((operation == "load" || operation == "export") && string.IsNullOrWhiteSpace(DataFileName))
+            {
+                await connection.SendChatMessage($"'{operation}' needs a file name.");
+                await connection.SendChatMessage("Usage: !accountdata <list|load|export|help> <file_name>");
+                return;
+            }
+
+            switch (operation)
             {
                 case "list":
                     await ListData();

--- a/Shittim-Server/Controllers/ManagementController.cs
+++ b/Shittim-Server/Controllers/ManagementController.cs
@@ -63,10 +63,15 @@ public class ManagementController : ControllerBase
         if (request == null || string.IsNullOrWhiteSpace(request.Name) || string.IsNullOrWhiteSpace(request.Content))
             return BadRequest(new { error = "name and content are required" });
 
-        // Only ever write a bare file name into the folder: a name carrying directory
-        // separators or ".." would otherwise land anywhere on disk.
-        var name = Path.GetFileName(request.Name);
-        if (string.IsNullOrWhiteSpace(name) || !name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+        // Only ever write a bare file name into the folder. Reject anything carrying directory
+        // parts rather than quietly stripping them: silently turning "../../evil.json" into
+        // "evil.json" contains the write but hides that the caller asked for something else.
+        var name = request.Name.Trim();
+        if (name != Path.GetFileName(name) || name.Contains(".."))
+            return BadRequest(new { error = "name must be a bare file name, without directories" });
+        if (name.IndexOfAny(Path.GetInvalidFileNameChars()) >= 0)
+            return BadRequest(new { error = "name contains characters that are not valid in a file name" });
+        if (!name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
             return BadRequest(new { error = "name must be a .json file" });
 
         try { using var _ = JsonDocument.Parse(request.Content); }

--- a/Shittim-Server/Controllers/ManagementController.cs
+++ b/Shittim-Server/Controllers/ManagementController.cs
@@ -54,8 +54,7 @@ public class ManagementController : ControllerBase
         public string Content { get; set; } = "";
     }
 
-    // Store a profile in the folder `accountdata load` reads. Takes content rather than a
-    // path so it works when the Control Center and the server are on different machines.
+    // Store a profile in the folder `accountdata load` reads. Takes content rather than a path so it works when the Control Center and the server are on different machines.
     [HttpPost("accountdata/upload")]
     public IActionResult UploadAccountData([FromBody] UploadAccountDataRequest request)
     {

--- a/Shittim-Server/Controllers/ManagementController.cs
+++ b/Shittim-Server/Controllers/ManagementController.cs
@@ -54,18 +54,15 @@ public class ManagementController : ControllerBase
         public string Content { get; set; } = "";
     }
 
-    // Copy a profile chosen from anywhere on disk into the folder `accountdata load` reads.
-    // Takes the content rather than a path so it still works when the Control Center and the
-    // server are not on the same machine.
+    // Store a profile in the folder `accountdata load` reads. Takes content rather than a
+    // path so it works when the Control Center and the server are on different machines.
     [HttpPost("accountdata/upload")]
     public IActionResult UploadAccountData([FromBody] UploadAccountDataRequest request)
     {
         if (request == null || string.IsNullOrWhiteSpace(request.Name) || string.IsNullOrWhiteSpace(request.Content))
             return BadRequest(new { error = "name and content are required" });
 
-        // Only ever write a bare file name into the folder. Reject anything carrying directory
-        // parts rather than quietly stripping them: silently turning "../../evil.json" into
-        // "evil.json" contains the write but hides that the caller asked for something else.
+        // Reject directory parts rather than stripping them, so the write cannot escape.
         var name = request.Name.Trim();
         if (name != Path.GetFileName(name) || name.Contains(".."))
             return BadRequest(new { error = "name must be a bare file name, without directories" });
@@ -77,7 +74,7 @@ public class ManagementController : ControllerBase
         try { using var _ = JsonDocument.Parse(request.Content); }
         catch (JsonException e) { return BadRequest(new { error = $"not valid JSON: {e.Message}" }); }
 
-        var dir = Shittim.Commands.AccountDataCommand.accountDataDir;
+        var dir = AccountDataCommand.accountDataDir;
         Directory.CreateDirectory(dir);
         var dest = Path.Combine(dir, name);
         System.IO.File.WriteAllText(dest, request.Content);

--- a/Shittim-Server/Controllers/ManagementController.cs
+++ b/Shittim-Server/Controllers/ManagementController.cs
@@ -48,6 +48,58 @@ public class ManagementController : ControllerBase
         _mapper = mapper;
     }
 
+    // Saved profiles available to `accountdata load`. A plain listing rather than a wrapper
+    // around the console command, because that route needs an account id to build a client
+    // connection -- which makes listing impossible on a server with no accounts yet, exactly
+    // when you want to create one FROM a profile.
+    [HttpGet("accountdata/files")]
+    public IActionResult AccountDataFiles()
+    {
+        var dir = Shittim.Commands.AccountDataCommand.accountDataDir;
+        if (!Directory.Exists(dir))
+            return Ok(new { files = Array.Empty<string>() });
+
+        var files = Directory.GetFiles(dir, "*.json")
+            .Select(f => new FileInfo(f))
+            .OrderByDescending(f => f.LastWriteTimeUtc)
+            .Select(f => new { name = f.Name, size = f.Length, modified = f.LastWriteTimeUtc })
+            .ToArray();
+
+        return Ok(new { files });
+    }
+
+    public class UploadAccountDataRequest
+    {
+        public string Name { get; set; } = "";
+        public string Content { get; set; } = "";
+    }
+
+    // Copy a profile chosen from anywhere on disk into the folder `accountdata load` reads.
+    // Takes the content rather than a path so it still works when the Control Center and the
+    // server are not on the same machine.
+    [HttpPost("accountdata/upload")]
+    public IActionResult UploadAccountData([FromBody] UploadAccountDataRequest request)
+    {
+        if (request == null || string.IsNullOrWhiteSpace(request.Name) || string.IsNullOrWhiteSpace(request.Content))
+            return BadRequest(new { error = "name and content are required" });
+
+        // Only ever write a bare file name into the folder: a name carrying directory
+        // separators or ".." would otherwise land anywhere on disk.
+        var name = Path.GetFileName(request.Name);
+        if (string.IsNullOrWhiteSpace(name) || !name.EndsWith(".json", StringComparison.OrdinalIgnoreCase))
+            return BadRequest(new { error = "name must be a .json file" });
+
+        try { using var _ = JsonDocument.Parse(request.Content); }
+        catch (JsonException e) { return BadRequest(new { error = $"not valid JSON: {e.Message}" }); }
+
+        var dir = Shittim.Commands.AccountDataCommand.accountDataDir;
+        Directory.CreateDirectory(dir);
+        var dest = Path.Combine(dir, name);
+        System.IO.File.WriteAllText(dest, request.Content);
+
+        return Ok(new { success = true, name });
+    }
+
     [HttpGet("status")]
     public async Task<IActionResult> Status()
     {

--- a/Shittim-Server/Controllers/ManagementController.cs
+++ b/Shittim-Server/Controllers/ManagementController.cs
@@ -48,26 +48,6 @@ public class ManagementController : ControllerBase
         _mapper = mapper;
     }
 
-    // Saved profiles available to `accountdata load`. A plain listing rather than a wrapper
-    // around the console command, because that route needs an account id to build a client
-    // connection -- which makes listing impossible on a server with no accounts yet, exactly
-    // when you want to create one FROM a profile.
-    [HttpGet("accountdata/files")]
-    public IActionResult AccountDataFiles()
-    {
-        var dir = Shittim.Commands.AccountDataCommand.accountDataDir;
-        if (!Directory.Exists(dir))
-            return Ok(new { files = Array.Empty<string>() });
-
-        var files = Directory.GetFiles(dir, "*.json")
-            .Select(f => new FileInfo(f))
-            .OrderByDescending(f => f.LastWriteTimeUtc)
-            .Select(f => new { name = f.Name, size = f.Length, modified = f.LastWriteTimeUtc })
-            .ToArray();
-
-        return Ok(new { files });
-    }
-
     public class UploadAccountDataRequest
     {
         public string Name { get; set; } = "";

--- a/Shittim-Server/Utils/Loaddata.cs
+++ b/Shittim-Server/Utils/Loaddata.cs
@@ -98,8 +98,7 @@ namespace Shittim.Utils
 		public MultiFloorRaidSyncResponse MultiFloorRaidSyncResponse { get; set; }
 		public long FriendCount { get; set; }
 		public string FriendCode { get; set; }
-		// The ID card and its backgrounds arrive in the friend-list packet rather than the
-		// login bundle, so a capture-derived save carries them spliced onto it.
+		// Spliced onto the bundle by the exporter; they arrive in the friend-list packet.
 		public FriendIdCardDB FriendIdCardDB { get; set; }
 		public List<IdCardBackgroundDB> IdCardBackgroundDBs { get; set; }
 	}

--- a/Shittim-Server/Utils/Loaddata.cs
+++ b/Shittim-Server/Utils/Loaddata.cs
@@ -98,6 +98,10 @@ namespace Shittim.Utils
 		public MultiFloorRaidSyncResponse MultiFloorRaidSyncResponse { get; set; }
 		public long FriendCount { get; set; }
 		public string FriendCode { get; set; }
+		// The ID card and its backgrounds arrive in the friend-list packet rather than the
+		// login bundle, so a capture-derived save carries them spliced onto it.
+		public FriendIdCardDB FriendIdCardDB { get; set; }
+		public List<IdCardBackgroundDB> IdCardBackgroundDBs { get; set; }
 	}
 
 	public class ImportItemListRequest

--- a/Shittim-Server/config/ba_version_cache.json
+++ b/Shittim-Server/config/ba_version_cache.json
@@ -2,5 +2,5 @@
   "VersionId": "53c8e5c4ff484d23",
   "CdnBaseUrl": "https://ba.dn.nexoncdn.co.kr/com.nexon.bluearchive/53c8e5c4ff484d23",
   "SourceBuildVersion": "1.90.439170",
-  "LastUpdatedUtc": "2026-08-14T14:19:53.4237207Z"
+  "LastUpdatedUtc": "2026-08-12T00:57:53.1640481Z"
 }

--- a/Shittim-Server/config/ba_version_cache.json
+++ b/Shittim-Server/config/ba_version_cache.json
@@ -2,5 +2,5 @@
   "VersionId": "53c8e5c4ff484d23",
   "CdnBaseUrl": "https://ba.dn.nexoncdn.co.kr/com.nexon.bluearchive/53c8e5c4ff484d23",
   "SourceBuildVersion": "1.90.439170",
-  "LastUpdatedUtc": "2026-08-12T00:57:53.1640481Z"
+  "LastUpdatedUtc": "2026-08-14T14:19:53.4237207Z"
 }

--- a/ShittimControlCenter/main.js
+++ b/ShittimControlCenter/main.js
@@ -1046,6 +1046,30 @@ async function buildDiagnosticInfo() {
   ].join('\r\n');
 }
 
+// Pick a saved profile from anywhere on disk. The server can only load files sitting in its
+// own AccountData folder, so the renderer uploads what this returns rather than passing a
+// path -- that also keeps working when the server is not on this machine.
+async function pickAccountDataFile() {
+  const res = await dialog.showOpenDialog({
+    title: 'Import profile',
+    defaultPath: documentsDir(),
+    filters: [{ name: 'Account profile', extensions: ['json'] }],
+    properties: ['openFile'],
+  });
+  if (res.canceled || !res.filePaths?.length) return { ok: false, canceled: true };
+
+  const file = res.filePaths[0];
+  try {
+    const content = fs.readFileSync(file, 'utf8');
+    // Fail here rather than server-side, so the message names the file the user just chose.
+    try { JSON.parse(content); }
+    catch { return { ok: false, error: `${path.basename(file)} is not valid JSON` }; }
+    return { ok: true, name: path.basename(file), content };
+  } catch (e) {
+    return { ok: false, error: e.message };
+  }
+}
+
 async function exportLogs() {
   const p = resolvePaths();
   const stamp = new Date().toISOString().replace(/[:T]/g, '-').replace(/\..+$/, '');
@@ -1282,6 +1306,7 @@ function createWindow() {
   return win;
 }
 
+ipcMain.handle('accountdata:pick', () => pickAccountDataFile());
 ipcMain.handle('paths:resolve', () => resolvePaths());
 ipcMain.handle('settings:read', () => loadSettings());
 // The renderer writes window geometry through here and does not wait on it, so a failure is reported rather than thrown back at it.

--- a/ShittimControlCenter/main.js
+++ b/ShittimControlCenter/main.js
@@ -1046,8 +1046,7 @@ async function buildDiagnosticInfo() {
   ].join('\r\n');
 }
 
-// Returns the chosen profile's name and content; the renderer uploads it, since the server
-// only loads from its own folder and may not be on this machine.
+// Returns the chosen profile's name and content; the renderer uploads it, since the server only loads from its own folder and may not be on this machine.
 async function pickAccountDataFile() {
   const res = await dialog.showOpenDialog({
     title: 'Import profile',
@@ -1060,7 +1059,6 @@ async function pickAccountDataFile() {
   const file = res.filePaths[0];
   try {
     const content = fs.readFileSync(file, 'utf8');
-    // Checked here so the message can name the file just chosen.
     try { JSON.parse(content); }
     catch { return { ok: false, error: `${path.basename(file)} is not valid JSON` }; }
     return { ok: true, name: path.basename(file), content };

--- a/ShittimControlCenter/main.js
+++ b/ShittimControlCenter/main.js
@@ -1046,9 +1046,8 @@ async function buildDiagnosticInfo() {
   ].join('\r\n');
 }
 
-// Pick a saved profile from anywhere on disk. The server can only load files sitting in its
-// own AccountData folder, so the renderer uploads what this returns rather than passing a
-// path -- that also keeps working when the server is not on this machine.
+// Returns the chosen profile's name and content; the renderer uploads it, since the server
+// only loads from its own folder and may not be on this machine.
 async function pickAccountDataFile() {
   const res = await dialog.showOpenDialog({
     title: 'Import profile',
@@ -1061,7 +1060,7 @@ async function pickAccountDataFile() {
   const file = res.filePaths[0];
   try {
     const content = fs.readFileSync(file, 'utf8');
-    // Fail here rather than server-side, so the message names the file the user just chose.
+    // Checked here so the message can name the file just chosen.
     try { JSON.parse(content); }
     catch { return { ok: false, error: `${path.basename(file)} is not valid JSON` }; }
     return { ok: true, name: path.basename(file), content };

--- a/ShittimControlCenter/preload.js
+++ b/ShittimControlCenter/preload.js
@@ -4,6 +4,7 @@ const { contextBridge, ipcRenderer } = require('electron');
 
 contextBridge.exposeInMainWorld('host', {
   paths: () => ipcRenderer.invoke('paths:resolve'),
+  pickAccountData: () => ipcRenderer.invoke('accountdata:pick'),
   settingsRead: () => ipcRenderer.invoke('settings:read'),
   settingsWrite: (patch) => ipcRenderer.invoke('settings:write', patch),
 

--- a/ShittimControlCenter/src/js/api.js
+++ b/ShittimControlCenter/src/js/api.js
@@ -102,6 +102,9 @@ export const api = {
 
   command: (uid, command) => req('POST', '/api/admin/command', { uid, command }),
 
+  accountDataFiles: () => req('GET', '/api/admin/accountdata/files'),
+  accountDataUpload: (b) => req('POST', '/api/admin/accountdata/upload', b),
+
   staticItems: (q) => req('GET', `/api/admin/static/items?limit=400&search=${encodeURIComponent(q || '')}`),
   staticCharacters: (q) => req('GET', `/api/admin/static/characters?limit=600&search=${encodeURIComponent(q || '')}`),
   staticEquipment: (q) => req('GET', `/api/admin/static/equipment?limit=400&search=${encodeURIComponent(q || '')}`),

--- a/ShittimControlCenter/src/js/api.js
+++ b/ShittimControlCenter/src/js/api.js
@@ -102,7 +102,6 @@ export const api = {
 
   command: (uid, command) => req('POST', '/api/admin/command', { uid, command }),
 
-  accountDataFiles: () => req('GET', '/api/admin/accountdata/files'),
   accountDataUpload: (b) => req('POST', '/api/admin/accountdata/upload', b),
 
   staticItems: (q) => req('GET', `/api/admin/static/items?limit=400&search=${encodeURIComponent(q || '')}`),

--- a/ShittimControlCenter/src/js/pages/accounts.js
+++ b/ShittimControlCenter/src/js/pages/accounts.js
@@ -189,7 +189,6 @@ export default {
         notifyRestart();
       }
 
-      // Uploads the chosen file to the server and returns its stored name, or null.
       async function pickProfile() {
         if (!window.host?.pickAccountData) { toast('File picker unavailable', 'bad'); return null; }
         const picked = await window.host.pickAccountData();
@@ -201,7 +200,6 @@ export default {
         } catch (e) { toast(e.message, 'bad'); return null; }
       }
 
-      // Browse button plus a label of the current choice. `onPick` gets the stored name.
       function profilePicker(onPick) {
         const chosen = el('span.muted', { text: 'No file chosen', style: { fontSize: '12px' } });
         const browse = button('Browse...', { variant: 'ghost', sm: true, iconName: 'folder',
@@ -222,9 +220,7 @@ export default {
         if (out && !/successfully/i.test(out)) throw new Error(out);
       }
 
-      // Import creates a new account, never replaces one. Loading over an account the client
-      // has already logged into leaves it holding stale cached state -- the level it shows
-      // stops matching the level on the server. A fresh account has no such history.
+      // Only ever creates a new account: loading over one the client has already logged into leaves it holding stale cached state and the level it shows stops matching the server.
       function openCreate() {
         const nick = input({ value: 'Sensei' });
 

--- a/ShittimControlCenter/src/js/pages/accounts.js
+++ b/ShittimControlCenter/src/js/pages/accounts.js
@@ -46,10 +46,11 @@ export default {
 
       const searchInput = input({ placeholder: 'Filter...', className: 'input btn-sm', style: { height: '32px', width: '130px', minWidth: '0', flex: '0 1 130px' } });
       const createBtn = button('New', { variant: 'primary', sm: true, iconName: 'plus', onClick: openCreate });
+      const importBtn = button('Import', { variant: 'ghost', sm: true, iconName: 'download', onClick: openImport });
       const refreshBtn = button('', { variant: 'ghost', sm: true, iconName: 'refresh', onClick: loadList });
 
       listCard.appendChild(el('div.card-head', {}, el('span.tab-mark', {}), el('h3', { text: 'Roster' }),
-        el('div.spacer', {}), searchInput, refreshBtn, createBtn));
+        el('div.spacer', {}), searchInput, refreshBtn, importBtn, createBtn));
       const listBody = el('div.list-scroll', { style: { maxHeight: '64vh' } });
       listCard.appendChild(listBody);
 
@@ -187,6 +188,105 @@ export default {
         for (const [cid, e] of Object.entries(edits)) { await api.setCurrency({ accountServerId: id, currencyType: Number(cid), amount: MAX }); e.input.value = MAX; e.orig = MAX; }
         toast('All shown currencies maxed', 'good');
         notifyRestart();
+      }
+
+      // Import a saved profile from the server's AccountData folder.
+      //
+      // Defaults to creating a NEW account rather than overwriting, because the load wipes the
+      // target's characters, items, gear, echelons, cafe and progress before inserting. Anyone
+      // importing usually wants their captured account *alongside* whatever they were already
+      // playing, and an unwanted new account is one click to delete -- an overwritten one is
+      // gone. Overwrite stays available, behind a danger confirm, since re-importing a fresher
+      // capture onto the same account is the other common case.
+      async function openImport() {
+        let files = [];
+        try {
+          files = await listProfiles();
+        } catch (e) {
+          toast(`Could not read AccountData: ${e.message}`, 'bad');
+          return;
+        }
+        if (!files.length) {
+          toast('No profiles in the server\'s AccountData folder', 'warn');
+          return;
+        }
+
+        const fileSel = select(files.map((f) => ({ value: f, label: f })));
+        const nick = input({ value: 'Sensei' });
+
+        const target = select([
+          { value: 'new', label: 'Create a new account' },
+          ...(store.get().targetId ? [{ value: 'overwrite', label: 'Overwrite the selected account' }] : []),
+        ]);
+
+        const nickRow = field('Nickname for the new account', nick);
+        const warn = el('div.muted', { style: { fontSize: '12px', marginTop: '10px' } });
+        const syncMode = () => {
+          const isNew = target.value === 'new';
+          nickRow.style.display = isNew ? '' : 'none';
+          warn.textContent = isNew
+            ? 'The profile is loaded into a fresh account. Nothing existing is touched.'
+            : 'Replaces that account\'s characters, items, gear, echelons, cafe and progress.';
+        };
+        target.addEventListener('change', syncMode);
+
+        const go = button('Import', { variant: 'primary', iconName: 'download' });
+        const cancel = button('Cancel', { variant: 'ghost' });
+        const ref = modal({
+          title: 'Import profile',
+          body: el('div', {}, field('Profile', fileSel), field('Import into', target), nickRow, warn),
+          footer: [cancel, go],
+        });
+        syncMode();
+        cancel.addEventListener('click', ref.close);
+
+        go.addEventListener('click', async () => {
+          const file = fileSel.value;
+          const overwrite = target.value === 'overwrite';
+          let uid = store.get().targetId;
+
+          if (overwrite) {
+            const row = allRows.find((a) => a.serverId === uid);
+            const ok = await confirmDialog({
+              title: 'Overwrite account', danger: true, confirmLabel: 'Overwrite',
+              message: `"${row ? row.nickname : uid}" (#${uid}) loses its characters, items, gear, echelons, cafe and progress, replaced by "${file}". This cannot be undone.`,
+            });
+            if (!ok) return;
+          }
+
+          go.disabled = true;
+          try {
+            if (!overwrite) {
+              const created = await api.accountCreate({ nickname: nick.value.trim() || 'Sensei' });
+              uid = created.serverId;
+            }
+            const r = await api.command(uid, `accountdata load ${file}`);
+            const out = String(r?.output || '').trim();
+            // The command reports failures in its output rather than as an HTTP error.
+            if (out && !/successfully/i.test(out)) throw new Error(out);
+
+            ref.close();
+            toast(overwrite ? `Imported into #${uid}` : `Imported "${file}" as #${uid}`, 'good');
+            store.set({ targetId: uid });
+            await loadList();
+            notifyRestart();
+          } catch (e) {
+            toast(e.message, 'bad');
+            go.disabled = false;
+          }
+        });
+      }
+
+      // `accountdata list` prints a header line then one file per line. It needs a connection
+      // id but only reads the folder, so any existing account will do.
+      async function listProfiles() {
+        const uid = store.get().targetId || allRows[0]?.serverId;
+        if (!uid) throw new Error('create an account first');
+        const r = await api.command(uid, 'accountdata list');
+        return String(r?.output || '')
+          .split(/\r?\n/)
+          .map((s) => s.trim())
+          .filter((s) => s.toLowerCase().endsWith('.json'));
       }
 
       function openCreate() {

--- a/ShittimControlCenter/src/js/pages/accounts.js
+++ b/ShittimControlCenter/src/js/pages/accounts.js
@@ -162,8 +162,6 @@ export default {
         tools.appendChild(cmdButton(d.serverId, 'Unlock all characters', 'giveall'));
         tools.appendChild(cmdButton(d.serverId, 'Unlock campaign + story', ['unlockall campaign', 'unlockall story']));
         tools.appendChild(cmdButton(d.serverId, 'Unlock battlepass', 'unlockall battlepass'));
-        tools.appendChild(button('Import profile...', { variant: 'ghost', sm: true, iconName: 'download',
-          onClick: () => openOverwrite(d) }));
         body.appendChild(tools);
 
         body.appendChild(frag(`<div class="muted" style="font-size:12px;margin-top:18px">${d.itemCount} items · ${d.characterCount} characters · ${d.mailCount} mails · ${escapeHtml(d.state || '')}</div>`));
@@ -224,39 +222,9 @@ export default {
         if (out && !/successfully/i.test(out)) throw new Error(out);
       }
 
-      // Destructive: the load wipes the target account first, so this sits behind a confirm.
-      function openOverwrite(d) {
-        let file = null;
-        const go = button('Import and replace', { variant: 'danger', iconName: 'download' });
-        go.disabled = true;
-        const picker = profilePicker((name) => { file = name; go.disabled = false; });
-
-        const cancel = button('Cancel', { variant: 'ghost' });
-        const ref = modal({
-          title: `Import into ${d.nickname}`,
-          body: el('div', {}, field('Profile', picker.row),
-            el('div.muted', { style: { fontSize: '12px', marginTop: '10px' },
-              text: "Replaces this account's characters, items, gear, echelons, cafe and progress. To keep this account as it is, import into a new one instead (Roster -> New)." })),
-          footer: [cancel, go],
-        });
-        cancel.addEventListener('click', ref.close);
-        go.addEventListener('click', async () => {
-          if (!file) return;
-          const ok = await confirmDialog({
-            title: 'Overwrite account', danger: true, confirmLabel: 'Overwrite',
-            message: `"${d.nickname}" (#${d.serverId}) loses its characters, items, gear, echelons, cafe and progress, replaced by "${file}". This cannot be undone.`,
-          });
-          if (!ok) return;
-          go.disabled = true;
-          try {
-            await loadProfile(d.serverId, file);
-            ref.close(); toast(`Imported into #${d.serverId}`, 'good');
-            await loadList(); notifyRestart();
-          } catch (e) { toast(e.message, 'bad'); go.disabled = false; }
-        });
-      }
-
-      // Optionally seeded from a profile. Safe direction: nothing existing is touched.
+      // Import creates a new account, never replaces one. Loading over an account the client
+      // has already logged into leaves it holding stale cached state -- the level it shows
+      // stops matching the level on the server. A fresh account has no such history.
       function openCreate() {
         const nick = input({ value: 'Sensei' });
 

--- a/ShittimControlCenter/src/js/pages/accounts.js
+++ b/ShittimControlCenter/src/js/pages/accounts.js
@@ -191,11 +191,7 @@ export default {
         notifyRestart();
       }
 
-      // Pick a profile from anywhere on disk and copy it into the folder the server loads from.
-      // The user points at their own file, so there is no list to browse and nothing has to be
-      // placed in the server's folder by hand -- which also means this works the same whether
-      // the server is a source build or the packaged release, where that folder lives elsewhere.
-      // Returns the stored file name, or null if cancelled/failed.
+      // Uploads the chosen file to the server and returns its stored name, or null.
       async function pickProfile() {
         if (!window.host?.pickAccountData) { toast('File picker unavailable', 'bad'); return null; }
         const picked = await window.host.pickAccountData();
@@ -207,8 +203,7 @@ export default {
         } catch (e) { toast(e.message, 'bad'); return null; }
       }
 
-      // A Browse button paired with a label showing what is currently chosen. `onPick` fires
-      // with the stored file name so the caller can react (enable its confirm button, etc).
+      // Browse button plus a label of the current choice. `onPick` gets the stored name.
       function profilePicker(onPick) {
         const chosen = el('span.muted', { text: 'No file chosen', style: { fontSize: '12px' } });
         const browse = button('Browse...', { variant: 'ghost', sm: true, iconName: 'folder',
@@ -229,10 +224,7 @@ export default {
         if (out && !/successfully/i.test(out)) throw new Error(out);
       }
 
-      // Importing onto an existing account. Separate from creation because the load WIPES the
-      // target's characters, items, gear, echelons, cafe and progress first -- so it belongs
-      // with the other per-account tools, behind a confirm that names what it destroys, rather
-      // than anywhere it could be hit casually.
+      // Destructive: the load wipes the target account first, so this sits behind a confirm.
       function openOverwrite(d) {
         let file = null;
         const go = button('Import and replace', { variant: 'danger', iconName: 'download' });
@@ -264,16 +256,10 @@ export default {
         });
       }
 
-      // Creating an account, optionally seeded from a saved profile. Importing into a NEW
-      // account is the safe direction -- nothing existing is touched -- so it lives here rather
-      // than as a separate action. Importing onto an account that already has data is the
-      // destructive one and sits in that account's tools instead.
+      // Optionally seeded from a profile. Safe direction: nothing existing is touched.
       function openCreate() {
         const nick = input({ value: 'Sensei' });
 
-        // Importing into a NEW account is the safe direction -- nothing existing is touched --
-        // so it lives here. Importing onto an account that already has data is destructive and
-        // sits in that account's own tools instead.
         let file = null;
         const picker = profilePicker((name) => { file = name; syncHint(); });
         const hint = el('div.muted', { style: { fontSize: '12px', marginTop: '10px' } });

--- a/ShittimControlCenter/src/js/pages/accounts.js
+++ b/ShittimControlCenter/src/js/pages/accounts.js
@@ -191,37 +191,35 @@ export default {
         notifyRestart();
       }
 
-      // Listed straight from the server rather than through `accountdata list`, because that
-      // route needs an account id to build a client connection -- so on a server with no
-      // accounts yet you could not see the profiles you wanted to create an account FROM.
-      async function listProfiles() {
-        const r = await api.accountDataFiles();
-        return (r?.files || []).map((f) => f.name);
-      }
-
-      // Pick a profile from anywhere on disk and copy it into the folder the server loads from,
-      // so nothing has to be placed there by hand. Returns the stored file name, or null when
-      // the dialog was cancelled. Repopulates `sel` and leaves the new file selected.
-      async function browseForProfile(sel) {
+      // Pick a profile from anywhere on disk and copy it into the folder the server loads from.
+      // The user points at their own file, so there is no list to browse and nothing has to be
+      // placed in the server's folder by hand -- which also means this works the same whether
+      // the server is a source build or the packaged release, where that folder lives elsewhere.
+      // Returns the stored file name, or null if cancelled/failed.
+      async function pickProfile() {
         if (!window.host?.pickAccountData) { toast('File picker unavailable', 'bad'); return null; }
         const picked = await window.host.pickAccountData();
         if (!picked || picked.canceled) return null;
         if (!picked.ok) { toast(picked.error || 'Could not read that file', 'bad'); return null; }
-
         try {
           const up = await api.accountDataUpload({ name: picked.name, content: picked.content });
-          const name = up?.name || picked.name;
-          const files = await listProfiles().catch(() => [name]);
-          clear(sel);
-          for (const f of (files.includes(name) ? files : [name, ...files])) {
-            const opt = document.createElement('option');
-            opt.value = f; opt.textContent = f;
-            sel.appendChild(opt);
-          }
-          sel.value = name;
-          toast(`Added "${name}"`, 'good');
-          return name;
+          return up?.name || picked.name;
         } catch (e) { toast(e.message, 'bad'); return null; }
+      }
+
+      // A Browse button paired with a label showing what is currently chosen. `onPick` fires
+      // with the stored file name so the caller can react (enable its confirm button, etc).
+      function profilePicker(onPick) {
+        const chosen = el('span.muted', { text: 'No file chosen', style: { fontSize: '12px' } });
+        const browse = button('Browse...', { variant: 'ghost', sm: true, iconName: 'folder',
+          onClick: async () => {
+            const name = await pickProfile();
+            if (!name) return;
+            chosen.textContent = name;
+            chosen.classList.remove('muted');
+            onPick(name);
+          } });
+        return { row: el('div.row', { style: { gap: '10px', alignItems: 'center' } }, browse, chosen), chosen };
       }
 
       // The load reports failure in its output rather than as an HTTP error.
@@ -235,32 +233,31 @@ export default {
       // target's characters, items, gear, echelons, cafe and progress first -- so it belongs
       // with the other per-account tools, behind a confirm that names what it destroys, rather
       // than anywhere it could be hit casually.
-      async function openOverwrite(d) {
-        const files = await listProfiles().catch(() => []);
-
-        const fileSel = select(files.map((f) => ({ value: f, label: f })));
-        const browse = button('Browse...', { variant: 'ghost', sm: true, iconName: 'folder',
-          onClick: () => browseForProfile(fileSel) });
+      function openOverwrite(d) {
+        let file = null;
         const go = button('Import and replace', { variant: 'danger', iconName: 'download' });
+        go.disabled = true;
+        const picker = profilePicker((name) => { file = name; go.disabled = false; });
+
         const cancel = button('Cancel', { variant: 'ghost' });
         const ref = modal({
           title: `Import into ${d.nickname}`,
-          body: el('div', {}, field('Profile', el('div.row', { style: { gap: '8px' } }, fileSel, browse)),
+          body: el('div', {}, field('Profile', picker.row),
             el('div.muted', { style: { fontSize: '12px', marginTop: '10px' },
               text: "Replaces this account's characters, items, gear, echelons, cafe and progress. To keep this account as it is, import into a new one instead (Roster -> New)." })),
           footer: [cancel, go],
         });
         cancel.addEventListener('click', ref.close);
         go.addEventListener('click', async () => {
-          if (!fileSel.value) { toast('Pick a profile first - use Browse to add one', 'warn'); return; }
+          if (!file) return;
           const ok = await confirmDialog({
             title: 'Overwrite account', danger: true, confirmLabel: 'Overwrite',
-            message: `"${d.nickname}" (#${d.serverId}) loses its characters, items, gear, echelons, cafe and progress, replaced by "${fileSel.value}". This cannot be undone.`,
+            message: `"${d.nickname}" (#${d.serverId}) loses its characters, items, gear, echelons, cafe and progress, replaced by "${file}". This cannot be undone.`,
           });
           if (!ok) return;
           go.disabled = true;
           try {
-            await loadProfile(d.serverId, fileSel.value);
+            await loadProfile(d.serverId, file);
             ref.close(); toast(`Imported into #${d.serverId}`, 'good');
             await loadList(); notifyRestart();
           } catch (e) { toast(e.message, 'bad'); go.disabled = false; }
@@ -271,55 +268,41 @@ export default {
       // account is the safe direction -- nothing existing is touched -- so it lives here rather
       // than as a separate action. Importing onto an account that already has data is the
       // destructive one and sits in that account's tools instead.
-      async function openCreate() {
+      function openCreate() {
         const nick = input({ value: 'Sensei' });
-        const files = await listProfiles().catch(() => []);
 
-        // Import is always offered, even with an empty AccountData folder -- Browse adds one.
-        const source = select([
-          { value: 'empty', label: 'Empty account' },
-          { value: 'profile', label: 'Import a saved profile' },
-        ]);
-        const fileSel = select(files.map((f) => ({ value: f, label: f })));
-        const browse = button('Browse...', { variant: 'ghost', sm: true, iconName: 'folder',
-          onClick: () => browseForProfile(fileSel) });
-        const fileRow = field('Profile', el('div.row', { style: { gap: '8px' } }, fileSel, browse));
+        // Importing into a NEW account is the safe direction -- nothing existing is touched --
+        // so it lives here. Importing onto an account that already has data is destructive and
+        // sits in that account's own tools instead.
+        let file = null;
+        const picker = profilePicker((name) => { file = name; syncHint(); });
         const hint = el('div.muted', { style: { fontSize: '12px', marginTop: '10px' } });
-
-        const syncMode = () => {
-          const importing = source.value === 'profile';
-          fileRow.style.display = importing ? '' : 'none';
-          hint.textContent = importing
-            ? (fileSel.options.length
-                ? 'The profile is loaded into this new account. Nothing existing is touched.'
-                : 'No profiles on the server yet - use Browse to pick one from disk.')
-            : '';
+        const syncHint = () => {
+          hint.textContent = file
+            ? 'This profile is loaded into the new account. Nothing existing is touched.'
+            : 'Optional. Leave empty for a fresh account, or pick an exported profile.';
         };
-        source.addEventListener('change', syncMode);
-        fileSel.addEventListener('change', syncMode);
+        syncHint();
 
         const create = button('Create account', { variant: 'primary', iconName: 'plus' });
         const cancel = button('Cancel', { variant: 'ghost' });
         const ref = modal({
           title: 'New account',
-          body: el('div', {}, field('Nickname', nick), field('Start from', source), fileRow, hint),
+          body: el('div', {}, field('Nickname', nick), field('Import a profile', picker.row), hint),
           footer: [cancel, create],
         });
-        syncMode();
         cancel.addEventListener('click', ref.close);
 
         create.addEventListener('click', async () => {
-          const importing = source.value === 'profile';
-          if (importing && !fileSel.value) { toast('Pick a profile first - use Browse to add one', 'warn'); return; }
           create.disabled = true;
           try {
             const r = await api.accountCreate({ nickname: nick.value.trim() || 'Sensei' });
-            if (importing) await loadProfile(r.serverId, fileSel.value);
+            if (file) await loadProfile(r.serverId, file);
             ref.close();
-            toast(importing ? `Created #${r.serverId} from "${fileSel.value}"` : `Created "${nick.value}" (#${r.serverId})`, 'good');
+            toast(file ? `Created #${r.serverId} from "${file}"` : `Created "${nick.value}" (#${r.serverId})`, 'good');
             store.set({ targetId: r.serverId });
             await loadList();
-            if (importing) notifyRestart();
+            if (file) notifyRestart();
           } catch (e) { toast(e.message, 'bad'); create.disabled = false; }
         });
       }

--- a/ShittimControlCenter/src/js/pages/accounts.js
+++ b/ShittimControlCenter/src/js/pages/accounts.js
@@ -46,11 +46,10 @@ export default {
 
       const searchInput = input({ placeholder: 'Filter...', className: 'input btn-sm', style: { height: '32px', width: '130px', minWidth: '0', flex: '0 1 130px' } });
       const createBtn = button('New', { variant: 'primary', sm: true, iconName: 'plus', onClick: openCreate });
-      const importBtn = button('Import', { variant: 'ghost', sm: true, iconName: 'download', onClick: openImport });
       const refreshBtn = button('', { variant: 'ghost', sm: true, iconName: 'refresh', onClick: loadList });
 
       listCard.appendChild(el('div.card-head', {}, el('span.tab-mark', {}), el('h3', { text: 'Roster' }),
-        el('div.spacer', {}), searchInput, refreshBtn, importBtn, createBtn));
+        el('div.spacer', {}), searchInput, refreshBtn, createBtn));
       const listBody = el('div.list-scroll', { style: { maxHeight: '64vh' } });
       listCard.appendChild(listBody);
 
@@ -163,6 +162,8 @@ export default {
         tools.appendChild(cmdButton(d.serverId, 'Unlock all characters', 'giveall'));
         tools.appendChild(cmdButton(d.serverId, 'Unlock campaign + story', ['unlockall campaign', 'unlockall story']));
         tools.appendChild(cmdButton(d.serverId, 'Unlock battlepass', 'unlockall battlepass'));
+        tools.appendChild(button('Import profile...', { variant: 'ghost', sm: true, iconName: 'download',
+          onClick: () => openOverwrite(d) }));
         body.appendChild(tools);
 
         body.appendChild(frag(`<div class="muted" style="font-size:12px;margin-top:18px">${d.itemCount} items · ${d.characterCount} characters · ${d.mailCount} mails · ${escapeHtml(d.state || '')}</div>`));
@@ -190,119 +191,135 @@ export default {
         notifyRestart();
       }
 
-      // Import a saved profile from the server's AccountData folder.
-      //
-      // Defaults to creating a NEW account rather than overwriting, because the load wipes the
-      // target's characters, items, gear, echelons, cafe and progress before inserting. Anyone
-      // importing usually wants their captured account *alongside* whatever they were already
-      // playing, and an unwanted new account is one click to delete -- an overwritten one is
-      // gone. Overwrite stays available, behind a danger confirm, since re-importing a fresher
-      // capture onto the same account is the other common case.
-      async function openImport() {
-        let files = [];
+      // Listed straight from the server rather than through `accountdata list`, because that
+      // route needs an account id to build a client connection -- so on a server with no
+      // accounts yet you could not see the profiles you wanted to create an account FROM.
+      async function listProfiles() {
+        const r = await api.accountDataFiles();
+        return (r?.files || []).map((f) => f.name);
+      }
+
+      // Pick a profile from anywhere on disk and copy it into the folder the server loads from,
+      // so nothing has to be placed there by hand. Returns the stored file name, or null when
+      // the dialog was cancelled. Repopulates `sel` and leaves the new file selected.
+      async function browseForProfile(sel) {
+        if (!window.host?.pickAccountData) { toast('File picker unavailable', 'bad'); return null; }
+        const picked = await window.host.pickAccountData();
+        if (!picked || picked.canceled) return null;
+        if (!picked.ok) { toast(picked.error || 'Could not read that file', 'bad'); return null; }
+
         try {
-          files = await listProfiles();
-        } catch (e) {
-          toast(`Could not read AccountData: ${e.message}`, 'bad');
-          return;
-        }
-        if (!files.length) {
-          toast('No profiles in the server\'s AccountData folder', 'warn');
-          return;
-        }
+          const up = await api.accountDataUpload({ name: picked.name, content: picked.content });
+          const name = up?.name || picked.name;
+          const files = await listProfiles().catch(() => [name]);
+          clear(sel);
+          for (const f of (files.includes(name) ? files : [name, ...files])) {
+            const opt = document.createElement('option');
+            opt.value = f; opt.textContent = f;
+            sel.appendChild(opt);
+          }
+          sel.value = name;
+          toast(`Added "${name}"`, 'good');
+          return name;
+        } catch (e) { toast(e.message, 'bad'); return null; }
+      }
+
+      // The load reports failure in its output rather than as an HTTP error.
+      async function loadProfile(uid, file) {
+        const r = await api.command(uid, `accountdata load ${file}`);
+        const out = String(r?.output || '').trim();
+        if (out && !/successfully/i.test(out)) throw new Error(out);
+      }
+
+      // Importing onto an existing account. Separate from creation because the load WIPES the
+      // target's characters, items, gear, echelons, cafe and progress first -- so it belongs
+      // with the other per-account tools, behind a confirm that names what it destroys, rather
+      // than anywhere it could be hit casually.
+      async function openOverwrite(d) {
+        const files = await listProfiles().catch(() => []);
 
         const fileSel = select(files.map((f) => ({ value: f, label: f })));
-        const nick = input({ value: 'Sensei' });
-
-        const target = select([
-          { value: 'new', label: 'Create a new account' },
-          ...(store.get().targetId ? [{ value: 'overwrite', label: 'Overwrite the selected account' }] : []),
-        ]);
-
-        const nickRow = field('Nickname for the new account', nick);
-        const warn = el('div.muted', { style: { fontSize: '12px', marginTop: '10px' } });
-        const syncMode = () => {
-          const isNew = target.value === 'new';
-          nickRow.style.display = isNew ? '' : 'none';
-          warn.textContent = isNew
-            ? 'The profile is loaded into a fresh account. Nothing existing is touched.'
-            : 'Replaces that account\'s characters, items, gear, echelons, cafe and progress.';
-        };
-        target.addEventListener('change', syncMode);
-
-        const go = button('Import', { variant: 'primary', iconName: 'download' });
+        const browse = button('Browse...', { variant: 'ghost', sm: true, iconName: 'folder',
+          onClick: () => browseForProfile(fileSel) });
+        const go = button('Import and replace', { variant: 'danger', iconName: 'download' });
         const cancel = button('Cancel', { variant: 'ghost' });
         const ref = modal({
-          title: 'Import profile',
-          body: el('div', {}, field('Profile', fileSel), field('Import into', target), nickRow, warn),
+          title: `Import into ${d.nickname}`,
+          body: el('div', {}, field('Profile', el('div.row', { style: { gap: '8px' } }, fileSel, browse)),
+            el('div.muted', { style: { fontSize: '12px', marginTop: '10px' },
+              text: "Replaces this account's characters, items, gear, echelons, cafe and progress. To keep this account as it is, import into a new one instead (Roster -> New)." })),
           footer: [cancel, go],
+        });
+        cancel.addEventListener('click', ref.close);
+        go.addEventListener('click', async () => {
+          if (!fileSel.value) { toast('Pick a profile first - use Browse to add one', 'warn'); return; }
+          const ok = await confirmDialog({
+            title: 'Overwrite account', danger: true, confirmLabel: 'Overwrite',
+            message: `"${d.nickname}" (#${d.serverId}) loses its characters, items, gear, echelons, cafe and progress, replaced by "${fileSel.value}". This cannot be undone.`,
+          });
+          if (!ok) return;
+          go.disabled = true;
+          try {
+            await loadProfile(d.serverId, fileSel.value);
+            ref.close(); toast(`Imported into #${d.serverId}`, 'good');
+            await loadList(); notifyRestart();
+          } catch (e) { toast(e.message, 'bad'); go.disabled = false; }
+        });
+      }
+
+      // Creating an account, optionally seeded from a saved profile. Importing into a NEW
+      // account is the safe direction -- nothing existing is touched -- so it lives here rather
+      // than as a separate action. Importing onto an account that already has data is the
+      // destructive one and sits in that account's tools instead.
+      async function openCreate() {
+        const nick = input({ value: 'Sensei' });
+        const files = await listProfiles().catch(() => []);
+
+        // Import is always offered, even with an empty AccountData folder -- Browse adds one.
+        const source = select([
+          { value: 'empty', label: 'Empty account' },
+          { value: 'profile', label: 'Import a saved profile' },
+        ]);
+        const fileSel = select(files.map((f) => ({ value: f, label: f })));
+        const browse = button('Browse...', { variant: 'ghost', sm: true, iconName: 'folder',
+          onClick: () => browseForProfile(fileSel) });
+        const fileRow = field('Profile', el('div.row', { style: { gap: '8px' } }, fileSel, browse));
+        const hint = el('div.muted', { style: { fontSize: '12px', marginTop: '10px' } });
+
+        const syncMode = () => {
+          const importing = source.value === 'profile';
+          fileRow.style.display = importing ? '' : 'none';
+          hint.textContent = importing
+            ? (fileSel.options.length
+                ? 'The profile is loaded into this new account. Nothing existing is touched.'
+                : 'No profiles on the server yet - use Browse to pick one from disk.')
+            : '';
+        };
+        source.addEventListener('change', syncMode);
+        fileSel.addEventListener('change', syncMode);
+
+        const create = button('Create account', { variant: 'primary', iconName: 'plus' });
+        const cancel = button('Cancel', { variant: 'ghost' });
+        const ref = modal({
+          title: 'New account',
+          body: el('div', {}, field('Nickname', nick), field('Start from', source), fileRow, hint),
+          footer: [cancel, create],
         });
         syncMode();
         cancel.addEventListener('click', ref.close);
 
-        go.addEventListener('click', async () => {
-          const file = fileSel.value;
-          const overwrite = target.value === 'overwrite';
-          let uid = store.get().targetId;
-
-          if (overwrite) {
-            const row = allRows.find((a) => a.serverId === uid);
-            const ok = await confirmDialog({
-              title: 'Overwrite account', danger: true, confirmLabel: 'Overwrite',
-              message: `"${row ? row.nickname : uid}" (#${uid}) loses its characters, items, gear, echelons, cafe and progress, replaced by "${file}". This cannot be undone.`,
-            });
-            if (!ok) return;
-          }
-
-          go.disabled = true;
-          try {
-            if (!overwrite) {
-              const created = await api.accountCreate({ nickname: nick.value.trim() || 'Sensei' });
-              uid = created.serverId;
-            }
-            const r = await api.command(uid, `accountdata load ${file}`);
-            const out = String(r?.output || '').trim();
-            // The command reports failures in its output rather than as an HTTP error.
-            if (out && !/successfully/i.test(out)) throw new Error(out);
-
-            ref.close();
-            toast(overwrite ? `Imported into #${uid}` : `Imported "${file}" as #${uid}`, 'good');
-            store.set({ targetId: uid });
-            await loadList();
-            notifyRestart();
-          } catch (e) {
-            toast(e.message, 'bad');
-            go.disabled = false;
-          }
-        });
-      }
-
-      // `accountdata list` prints a header line then one file per line. It needs a connection
-      // id but only reads the folder, so any existing account will do.
-      async function listProfiles() {
-        const uid = store.get().targetId || allRows[0]?.serverId;
-        if (!uid) throw new Error('create an account first');
-        const r = await api.command(uid, 'accountdata list');
-        return String(r?.output || '')
-          .split(/\r?\n/)
-          .map((s) => s.trim())
-          .filter((s) => s.toLowerCase().endsWith('.json'));
-      }
-
-      function openCreate() {
-        const nick = input({ value: 'Sensei' });
-        const create = button('Create account', { variant: 'primary', iconName: 'plus' });
-        const cancel = button('Cancel', { variant: 'ghost' });
-        const ref = modal({ title: 'New account', body: el('div', {}, field('Nickname', nick)),
-          footer: [cancel, create] });
-        cancel.addEventListener('click', ref.close);
         create.addEventListener('click', async () => {
+          const importing = source.value === 'profile';
+          if (importing && !fileSel.value) { toast('Pick a profile first - use Browse to add one', 'warn'); return; }
           create.disabled = true;
           try {
             const r = await api.accountCreate({ nickname: nick.value.trim() || 'Sensei' });
-            ref.close(); toast(`Created "${nick.value}" (#${r.serverId})`, 'good');
+            if (importing) await loadProfile(r.serverId, fileSel.value);
+            ref.close();
+            toast(importing ? `Created #${r.serverId} from "${fileSel.value}"` : `Created "${nick.value}" (#${r.serverId})`, 'good');
             store.set({ targetId: r.serverId });
             await loadList();
+            if (importing) notifyRestart();
           } catch (e) { toast(e.message, 'bad'); create.disabled = false; }
         });
       }


### PR DESCRIPTION
`!accountdata export` writes the whole account. `!accountdata load` only ever read part of it,
and lost some of what it did read. This makes the round trip lossless and adds an import
button to the Control Center.

## Bugs fixed

- **Items dropped** when they arrive in their own packet. The fallback that reads them assigned
  the list, then never wrote it: the insert sits in the `else` branch the fallback just skipped.
- **Colliding rows lost.** `AddItems`/`AddEquipment`/`AddGears`/`AddWeapons` pick insert vs merge
  with a DB query, called before the delete is saved, so they merge onto rows about to be
  deleted. Re-importing 369 equipment gave 360.
- **Currencies could go negative.** Recharge is `(now - UpdateTime) / interval` and the
  timestamps came from the source server. A clock ahead of this one made it subtract: 56 AP
  imported as -93.
- **Same save could not be imported twice.** Rows were inserted with the ids they had in the
  save, which are primary keys of tables shared by all accounts, so a second account collided
  and the import died half done.
- **`accountdata list` and `help` were unreachable**, rejected as "Invalid args length!" for a
  file name argument they do not take.

## Now restored

Written by `ExportData`, never read by `LoadData`:

- currencies, greeting, sensei name
- story and campaign progress
- costumes, emblems, momotalk, event content, sticker book, attachment
- free recruit history, crafting slots, multi floor raid
- ID card and owned backgrounds

Story and campaign progress matters most: without it an imported account is max level with
every content gate shut, which reads as a failed import rather than a partial one.

Several AutoMapper profiles only had the export direction, so those rows could not be written
back even in principle. The import direction is added alongside the existing reverse mappings.

## Control Center

- Import when creating an account: pick a save with a file browser, new account is created from
  it. The file is uploaded, so nothing has to be placed in `AccountData` by hand and it works
  with the server on another machine.
- Import only ever creates a new account. Loading over an account the client has already seen
  leaves it holding stale cached state and the displayed level drifts.

## Tested

Imported a real 168 student Global account. Every table matches the source:

```
168 characters   17 weapons    528 items      403 equipment   4 gear
39 echelons      155 memory lobby             264 furniture   2 cafes
533 scenario histories         1457 scenario groups
253 campaign stages            54 chapter rewards             9 strategy objects
110 emblems      160 momotalk  26 event content
5 free recruit   1 multi floor raid            16 ID card backgrounds
```

Imported the same save into two accounts: no shared ids, no dangling equipment or weapon
references, each represent character resolving to a row its own account owns.
